### PR TITLE
forwarding express request object as data

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -75,7 +75,7 @@ Mock.prototype.registerRoutes = function (req, res) {
                 latency = 0;
             }
 
-            var response = _routeResponse(route);
+            var response = _routeResponse(route, req);
 
             /* jshint ignore:start */
             setTimeout(function(){
@@ -102,7 +102,7 @@ module.exports = function (config) {
  * PRIVATE METHODS
  * */
 
-function _routeResponse (route) {
+function _routeResponse (route, req) {
     var response = null;
     var guid = route.name+route.testScope+route.testScenario;
 
@@ -130,9 +130,9 @@ function _routeResponse (route) {
                     jsonTemplate = route.jsonTemplate;
                 }
 				
-				if (route.data) {
-					dummyOptions.data = route.data;
-				}
+                dummyOptions.data = route.data || {};
+                dummyOptions.data.request = req;
+
 				if (route.helpers) {
 					dummyOptions.helpers = route.helpers;
 				}


### PR DESCRIPTION
Hi,

I recommend a fast way to include the request object from the running Express instance to allow some more magic in the helpers.
For example, I want to use the given parameters from the requested url. When I call `http://localhost:4000/api/v1/products/1001`, the generated object's id field should be `1001`, not `0`, as the `{{index}}` built-in helper generates it. So with this pull request, I will be able to write a helper that parses the request url.