### PR TITLE
Method based route restriction

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -40,7 +40,6 @@ Mock.prototype.registerRoutes = function (req, res) {
             matchingMethod = (routes[i].method.toLowerCase() === req.method.toLowerCase());
         }
 
-        console.log(routes[i].mockRoute + ' - ' + req.method + ' - ' + routes[i].method)
         if (req.path.match(routes[i].mockRoute) !== null && matchingMethod) {
 
             found = true;

--- a/mock.js
+++ b/mock.js
@@ -75,7 +75,7 @@ Mock.prototype.registerRoutes = function (req, res) {
                 latency = 0;
             }
 
-            var response = _routeResponse(route);
+            var response = _routeResponse(route, req);
 
             /* jshint ignore:start */
             setTimeout(function(){
@@ -102,7 +102,7 @@ module.exports = function (config) {
  * PRIVATE METHODS
  * */
 
-function _routeResponse (route) {
+function _routeResponse (route, req) {
     var response = null;
     var guid = route.name+route.testScope+route.testScenario;
 
@@ -130,9 +130,9 @@ function _routeResponse (route) {
                     jsonTemplate = route.jsonTemplate;
                 }
 				
-				if (route.data) {
-					dummyOptions.data = route.data;
-				}
+                dummyOptions.data = route.data || {};
+                dummyOptions.data.request = req;
+
 				if (route.helpers) {
 					dummyOptions.helpers = route.helpers;
 				}

--- a/mock.js
+++ b/mock.js
@@ -34,7 +34,14 @@ Mock.prototype.registerRoutes = function (req, res) {
     var found = false;
 
     for (var i = 0; i < routes.length; i++) {
-        if (req.path.match(routes[i].mockRoute) !== null) {
+        var matchingMethod = true;
+
+        if(typeof routes[i].method === 'string' || routes[i].method instanceof String){
+            matchingMethod = (routes[i].method.toLowerCase() === req.method.toLowerCase());
+        }
+
+        console.log(routes[i].mockRoute + ' - ' + req.method + ' - ' + routes[i].method)
+        if (req.path.match(routes[i].mockRoute) !== null && matchingMethod) {
 
             found = true;
 


### PR DESCRIPTION
Hi,
I added a feature to use the method parameter in the mockRoute. This allows devs to restrict the given route setup for a specific HTTP method, like GET or POST.

This is needed to use mock-json-api with a RESTfull API.