### PR TITLE
feat: add presets for switching entire experiences at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Node.js module for creating mock REST APIs with scenario support, perfect for 
 - **Zero app code changes** - Just point your API URL to the mock server
 - **Real HTTP server** - True REST behavior, not browser interception
 - **Scenario switching** - Easily switch between test scenarios via query params or API
+- **Presets** - Define named configurations to switch entire experiences at once
 - **State persistence** - Optional JSON file storage simulating a database
 - **State reset** - Reset all state between test runs via `POST /_reset`
 - **CORS enabled** - Works out of the box with frontend dev servers
@@ -69,6 +70,7 @@ app.listen(3001, () => console.log('Mock API running on port 3001'));
 | `mockRoutes` | Array | Yes | Array of route configurations |
 | `jsonStore` | String | No | File path for data persistence |
 | `cors` | Boolean/Object | No | CORS settings (default: enabled) |
+| `presets` | Object | No | Named preset configurations (see Presets) |
 
 ### Route options
 
@@ -218,6 +220,115 @@ POST /_scenario
 { "name": "getUsers", "scenario": "empty" }
 ```
 
+## Presets
+
+Presets allow you to define named configurations that set multiple routes' scenarios and scopes at once. This is useful for quickly switching between different "experiences" like happy path, error states, or new user flows.
+
+### Defining Presets
+
+```javascript
+const mockApi = mock({
+    mockRoutes: [
+        { name: 'getUsers', mockRoute: '/api/users', method: 'GET', testScope: 'success', testScenario: 0, jsonTemplate: [...] },
+        { name: 'getUser', mockRoute: '/api/users/:id', method: 'GET', testScope: 'success', jsonTemplate: '...' },
+        { name: 'createUser', mockRoute: '/api/users', method: 'POST', testScope: 'created', jsonTemplate: '...' },
+        { name: 'getOrders', mockRoute: '/api/orders', method: 'GET', testScope: 'success', jsonTemplate: '...' }
+    ],
+    presets: {
+        'happy-path': {
+            'getUsers': { scenario: 'many', scope: 'success' },
+            'getUser': { scope: 'success' },
+            'createUser': { scope: 'created' }
+        },
+        'new-user': {
+            'getUsers': { scenario: 'empty' },
+            'getUser': { scope: 'notFound' }
+        },
+        'error-mode': {
+            'getUsers': { scope: 'error' },
+            'createUser': { scope: 'badRequest' }
+        },
+        'slow-network': {
+            '*': { latency: 2000 }  // Wildcard applies to all routes
+        }
+    }
+});
+```
+
+### Preset Route Configuration
+
+Each route in a preset can set:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `scenario` | Number/String | The scenario to use for this route |
+| `scope` | String | The test scope (success, error, notFound, etc.) |
+| `latency` | Number/String | Response delay in ms |
+
+### Pattern Matching
+
+Presets support pattern matching for route names:
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `routeName` | Exact match | `'getUsers'` matches only `getUsers` |
+| `prefix*` | Prefix match | `'getUser*'` matches `getUsers`, `getUser`, `getUserById` |
+| `*` | All routes | `'*'` matches every route |
+
+### Activating a Preset
+
+**Via API:**
+```
+POST /_preset
+Content-Type: application/json
+
+{ "name": "happy-path" }
+```
+
+Response:
+```json
+{
+    "success": true,
+    "preset": "happy-path",
+    "message": "Preset 'happy-path' activated",
+    "routesUpdated": 3
+}
+```
+
+### Resetting to Default
+
+Send `null` or `"default"` as the name to reset all routes to their original configuration:
+
+```
+POST /_preset
+Content-Type: application/json
+
+{ "name": null }
+```
+
+or
+
+```
+POST /_preset
+Content-Type: application/json
+
+{ "name": "default" }
+```
+
+### Getting Available Presets
+
+```
+GET /_preset
+```
+
+Response:
+```json
+{
+    "active": "happy-path",
+    "available": ["happy-path", "new-user", "error-mode", "slow-network"]
+}
+```
+
 ## Request Body Access
 
 POST/PUT request bodies are automatically parsed:
@@ -354,6 +465,44 @@ test('handles server error gracefully', async () => {
 });
 ```
 
+### Using Presets in E2E Tests
+
+Presets make it easy to set up complex test scenarios with a single API call:
+
+```javascript
+describe('New user onboarding', () => {
+    beforeEach(async () => {
+        // Activate the new-user preset - sets up empty lists, not found states, etc.
+        await fetch('http://localhost:3001/_preset', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'new-user' })
+        });
+    });
+
+    test('shows onboarding flow for new users', async () => {
+        // All routes are now configured for new user experience
+        // Run your test...
+    });
+});
+
+describe('Error handling', () => {
+    beforeEach(async () => {
+        // Activate error-mode preset
+        await fetch('http://localhost:3001/_preset', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'error-mode' })
+        });
+    });
+
+    test('shows error states correctly', async () => {
+        // All routes are now configured to return errors
+        // Run your test...
+    });
+});
+```
+
 ## CORS Configuration
 
 CORS is enabled by default. To customize or disable:
@@ -407,6 +556,7 @@ Version 0.3.0 introduces several improvements while maintaining backward compati
 - Built-in body parsing
 - Express-style route parameters (`:id`)
 - `created` test scope (201 status)
+- **Presets** - Define named configurations to switch entire experiences at once via `POST /_preset`
 
 **Breaking changes:**
 - None - existing code continues to work

--- a/__tests__/mock.test.js
+++ b/__tests__/mock.test.js
@@ -457,4 +457,264 @@ describe('mock-json-api', () => {
             expect(JSON.parse(res.text).method).toBe('PATCH');
         });
     });
+
+    describe('Presets', () => {
+        beforeEach(() => {
+            mockApi = mock({
+                mockRoutes: [
+                    {
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        testScenario: 0,
+                        jsonTemplate: [
+                            () => '{ "users": [{"name": "John"}] }',
+                            () => '{ "users": [] }',
+                            { 'many': () => '{ "users": [{"name": "John"}, {"name": "Jane"}, {"name": "Bob"}] }' }
+                        ]
+                    },
+                    {
+                        name: 'getUser',
+                        mockRoute: '/api/users/:id',
+                        method: 'GET',
+                        testScope: 'success',
+                        testScenario: 0,
+                        jsonTemplate: '{ "user": { "id": 1, "name": "John" } }'
+                    },
+                    {
+                        name: 'createUser',
+                        mockRoute: '/api/users',
+                        method: 'POST',
+                        testScope: 'created',
+                        jsonTemplate: '{ "created": true }'
+                    },
+                    {
+                        name: 'getOrders',
+                        mockRoute: '/api/orders',
+                        method: 'GET',
+                        testScope: 'success',
+                        jsonTemplate: '{ "orders": [] }'
+                    }
+                ],
+                presets: {
+                    'happy-path': {
+                        'getUsers': { scenario: 'many', scope: 'success' },
+                        'getUser': { scope: 'success' },
+                        'createUser': { scope: 'created' }
+                    },
+                    'new-user': {
+                        'getUsers': { scenario: 1 },
+                        'getUser': { scope: 'notFound' }
+                    },
+                    'error-mode': {
+                        'getUsers': { scope: 'error' },
+                        'createUser': { scope: 'badRequest' }
+                    },
+                    'slow-network': {
+                        '*': { latency: 100 }
+                    },
+                    'user-errors': {
+                        'getUser*': { scope: 'error' }
+                    }
+                }
+            });
+            app = mockApi.createServer();
+        });
+
+        describe('GET /_preset', () => {
+            it('should return available presets and no active preset initially', async () => {
+                const res = await request(app).get('/_preset');
+                expect(res.status).toBe(200);
+                expect(res.body.active).toBeNull();
+                expect(res.body.available).toEqual([
+                    'happy-path',
+                    'new-user',
+                    'error-mode',
+                    'slow-network',
+                    'user-errors'
+                ]);
+            });
+
+            it('should show active preset after activation', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'happy-path' });
+
+                const res = await request(app).get('/_preset');
+                expect(res.body.active).toBe('happy-path');
+            });
+        });
+
+        describe('POST /_preset', () => {
+            it('should activate a preset and update routes', async () => {
+                const res = await request(app)
+                    .post('/_preset')
+                    .send({ name: 'happy-path' });
+
+                expect(res.status).toBe(200);
+                expect(res.body.success).toBe(true);
+                expect(res.body.preset).toBe('happy-path');
+                expect(res.body.routesUpdated).toBe(3);
+
+                // Verify route was updated
+                const route = mockApi.routes.find(r => r.name === 'getUsers');
+                expect(route.testScenario).toBe('many');
+            });
+
+            it('should return 404 for unknown preset', async () => {
+                const res = await request(app)
+                    .post('/_preset')
+                    .send({ name: 'unknown-preset' });
+
+                expect(res.status).toBe(404);
+                expect(res.body.success).toBe(false);
+                expect(res.body.available).toBeDefined();
+            });
+
+            it('should reset to default when name is null', async () => {
+                // First activate a preset
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'error-mode' });
+
+                // Verify preset is active
+                const route = mockApi.routes.find(r => r.name === 'getUsers');
+                expect(route.testScope).toBe('error');
+
+                // Reset to default
+                const res = await request(app)
+                    .post('/_preset')
+                    .send({ name: null });
+
+                expect(res.status).toBe(200);
+                expect(res.body.preset).toBe('default');
+
+                // Verify route is back to original
+                expect(route.testScope).toBe('success');
+            });
+
+            it('should reset to default when name is "default"', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'error-mode' });
+
+                const res = await request(app)
+                    .post('/_preset')
+                    .send({ name: 'default' });
+
+                expect(res.status).toBe(200);
+                expect(res.body.preset).toBe('default');
+
+                const presetRes = await request(app).get('/_preset');
+                expect(presetRes.body.active).toBeNull();
+            });
+        });
+
+        describe('Preset effects on routes', () => {
+            it('should change route scope via preset', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'error-mode' });
+
+                const res = await request(app).get('/api/users');
+                expect(res.status).toBe(500);
+            });
+
+            it('should change route scenario via preset', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'new-user' });
+
+                const res = await request(app).get('/api/users');
+                const body = JSON.parse(res.text);
+                expect(body.users).toEqual([]);
+            });
+
+            it('should apply latency via preset with wildcard', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'slow-network' });
+
+                // Verify all routes have latency set
+                for (const route of mockApi.routes) {
+                    expect(route.latency).toBe(100);
+                }
+            });
+        });
+
+        describe('Wildcard pattern matching', () => {
+            it('should match all routes with * pattern', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'slow-network' });
+
+                // All 4 routes should have latency
+                expect(mockApi.routes.every(r => r.latency === 100)).toBe(true);
+            });
+
+            it('should match routes by prefix with prefix* pattern', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'user-errors' });
+
+                // Only getUsers and getUser should be affected (start with 'getUser')
+                const getUsersRoute = mockApi.routes.find(r => r.name === 'getUsers');
+                const getUserRoute = mockApi.routes.find(r => r.name === 'getUser');
+                const createUserRoute = mockApi.routes.find(r => r.name === 'createUser');
+                const getOrdersRoute = mockApi.routes.find(r => r.name === 'getOrders');
+
+                expect(getUsersRoute.testScope).toBe('error');
+                expect(getUserRoute.testScope).toBe('error');
+                expect(createUserRoute.testScope).toBe('created'); // unchanged
+                expect(getOrdersRoute.testScope).toBe('success'); // unchanged
+            });
+        });
+
+        describe('Preset and reset interaction', () => {
+            it('should clear active preset on POST /_reset', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'happy-path' });
+
+                await request(app).post('/_reset');
+
+                const res = await request(app).get('/_preset');
+                expect(res.body.active).toBeNull();
+            });
+
+            it('should reset routes to original config on POST /_reset', async () => {
+                await request(app)
+                    .post('/_preset')
+                    .send({ name: 'error-mode' });
+
+                const routeBefore = mockApi.routes.find(r => r.name === 'getUsers');
+                expect(routeBefore.testScope).toBe('error');
+
+                await request(app).post('/_reset');
+
+                const routeAfter = mockApi.routes.find(r => r.name === 'getUsers');
+                expect(routeAfter.testScope).toBe('success');
+            });
+        });
+
+        describe('Empty presets configuration', () => {
+            it('should work without presets defined', async () => {
+                const apiWithoutPresets = mock({
+                    mockRoutes: [{
+                        name: 'test',
+                        mockRoute: '/api/test',
+                        method: 'GET',
+                        testScope: 'success',
+                        jsonTemplate: '{}'
+                    }]
+                });
+                const appWithoutPresets = apiWithoutPresets.createServer();
+
+                const res = await request(appWithoutPresets).get('/_preset');
+                expect(res.status).toBe(200);
+                expect(res.body.available).toEqual([]);
+            });
+        });
+    });
 });

--- a/mock.js
+++ b/mock.js
@@ -78,13 +78,16 @@ function Mock(config) {
     this.store = new DataStore(config.jsonStore);
     this.routes = config.mockRoutes;
     this.config = config;
+    this.presets = config.presets || {};
+    this.activePreset = null;
 
     // Store original route configurations for reset
     this.originalRoutes = JSON.parse(JSON.stringify(
         config.mockRoutes.map(r => ({
             name: r.name,
             testScope: r.testScope,
-            testScenario: r.testScenario
+            testScenario: r.testScenario,
+            latency: r.latency
         }))
     ));
 
@@ -131,6 +134,15 @@ Mock.prototype.createServer = function() {
         this.setRouteScenario(req, res);
     });
 
+    // Preset endpoints
+    app.get('/_preset', (req, res) => {
+        this.getPresets(req, res);
+    });
+
+    app.post('/_preset', (req, res) => {
+        this.setPreset(req, res);
+    });
+
     // Register mock routes
     app.use((req, res, next) => {
         this.registerRoutes(req, res, next);
@@ -146,12 +158,16 @@ Mock.prototype.reset = function() {
     // Clear the data store
     this.store.clear();
 
+    // Clear active preset
+    this.activePreset = null;
+
     // Reset all routes to original configuration
     this.originalRoutes.forEach(original => {
         const route = this.routes.find(r => r.name === original.name);
         if (route) {
             route.testScope = original.testScope;
             route.testScenario = original.testScenario;
+            route.latency = original.latency;
         }
     });
 };
@@ -301,6 +317,108 @@ Mock.prototype.setRouteScenario = function(req, res) {
         message: found ? 'Mock route updated.' : 'Mock route name not found.',
         route: found ? route : null
     });
+};
+
+/**
+ * Get available presets and active preset
+ */
+Mock.prototype.getPresets = function(req, res) {
+    res.json({
+        active: this.activePreset,
+        available: Object.keys(this.presets)
+    });
+};
+
+/**
+ * Activate a preset
+ */
+Mock.prototype.setPreset = function(req, res) {
+    const presetName = req.body.name;
+
+    // Reset to default if null, undefined, or "default"
+    if (presetName === null || presetName === undefined || presetName === 'default') {
+        this.reset();
+        this.activePreset = null;
+        return res.json({
+            success: true,
+            preset: 'default',
+            message: 'Reset to default configuration',
+            routesUpdated: this.routes.length
+        });
+    }
+
+    // Check if preset exists
+    if (!this.presets.hasOwnProperty(presetName)) {
+        return res.status(404).json({
+            success: false,
+            message: `Preset '${presetName}' not found`,
+            available: Object.keys(this.presets)
+        });
+    }
+
+    const preset = this.presets[presetName];
+    let routesUpdated = 0;
+
+    // First, reset all routes to original configuration
+    this.originalRoutes.forEach(original => {
+        const route = this.routes.find(r => r.name === original.name);
+        if (route) {
+            route.testScope = original.testScope;
+            route.testScenario = original.testScenario;
+            route.latency = original.latency;
+        }
+    });
+
+    // Clear the data store to regenerate responses
+    this.store.clear();
+
+    // Apply preset configurations
+    for (const [pattern, config] of Object.entries(preset)) {
+        const matchingRoutes = this._matchRoutesByPattern(pattern);
+
+        for (const route of matchingRoutes) {
+            if (config.scenario !== undefined) {
+                route.testScenario = config.scenario;
+            }
+            if (config.scope !== undefined) {
+                route.testScope = config.scope;
+            }
+            if (config.latency !== undefined) {
+                route.latency = config.latency;
+            }
+            routesUpdated++;
+        }
+    }
+
+    this.activePreset = presetName;
+
+    res.json({
+        success: true,
+        preset: presetName,
+        message: `Preset '${presetName}' activated`,
+        routesUpdated: routesUpdated
+    });
+};
+
+/**
+ * Match routes by pattern (supports wildcards)
+ * @param {string} pattern - Route name pattern ('*' for all, 'users*' for prefix match)
+ * @returns {Array} - Matching routes
+ */
+Mock.prototype._matchRoutesByPattern = function(pattern) {
+    if (pattern === '*') {
+        return this.routes;
+    }
+
+    // Check for wildcard prefix match (e.g., 'users*')
+    if (pattern.endsWith('*')) {
+        const prefix = pattern.slice(0, -1);
+        return this.routes.filter(route => route.name && route.name.startsWith(prefix));
+    }
+
+    // Exact match
+    const route = this.routes.find(r => r.name === pattern);
+    return route ? [route] : [];
 };
 
 Mock.prototype._routeResponse = function(route, req) {


### PR DESCRIPTION
## Summary

- Add **presets** feature to define named configurations that set multiple routes' scenarios, scopes, and latency at once
- Makes it easy to switch between test experiences like "happy-path", "error-mode", or "new-user" with a single API call
- Supports wildcard pattern matching (`*` for all routes, `prefix*` for prefix match)

## Changes

- `mock.js`: Added `presets` config, `GET /_preset`, `POST /_preset` endpoints, and pattern matching
- `__tests__/mock.test.js`: Added 13 new tests for preset functionality
- `README.md`: Added documentation for presets with examples

## Test plan

- [x] All 40 tests pass
- [x] Preset activation updates routes correctly
- [x] Wildcard patterns match expected routes
- [x] Reset to default works via `null` or `"default"`
- [x] Works without presets defined (backward compatible)

🤖 Generated with [Claude Code](https://claude.ai/code)