### PR TITLE
feat: add request logging option for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Node.js module for creating mock REST APIs with scenario support, perfect for 
 - **Real HTTP server** - True REST behavior, not browser interception
 - **Scenario switching** - Easily switch between test scenarios via query params or API
 - **Presets** - Define named configurations to switch entire experiences at once
+- **Request logging** - Debug your mock configuration with built-in logging
 - **State persistence** - Optional JSON file storage simulating a database
 - **State reset** - Reset all state between test runs via `POST /_reset`
 - **CORS enabled** - Works out of the box with frontend dev servers
@@ -71,6 +72,7 @@ app.listen(3001, () => console.log('Mock API running on port 3001'));
 | `jsonStore` | String | No | File path for data persistence |
 | `cors` | Boolean/Object | No | CORS settings (default: enabled) |
 | `presets` | Object | No | Named preset configurations (see Presets) |
+| `logging` | Boolean/String/Function | No | Request logging (see Logging) |
 
 ### Route options
 
@@ -433,6 +435,78 @@ Simulate network delays:
 }
 ```
 
+## Logging
+
+Enable request logging to see what routes are being hit and how they're being resolved. This is helpful for debugging mock configurations.
+
+### Basic Logging
+
+```javascript
+const mockApi = mock({
+    logging: true,
+    mockRoutes: [...]
+});
+```
+
+Output:
+```
+[mock-json-api] GET /api/users -> getUsers (success, scenario: 0) 200
+[mock-json-api] POST /api/users -> createUser (created) 201
+[mock-json-api] GET /api/unknown -> NOT FOUND (no matching route)
+```
+
+### Verbose Logging
+
+```javascript
+const mockApi = mock({
+    logging: 'verbose',
+    mockRoutes: [...]
+});
+```
+
+Output:
+```
+[mock-json-api] GET /api/users
+  Route: getUsers
+  Scope: success
+  Scenario: 0
+  Latency: 150ms
+  Response: 200
+```
+
+### Custom Logging Function
+
+Pass a function to handle logs yourself:
+
+```javascript
+const mockApi = mock({
+    logging: (info) => {
+        // info contains: method, url, routeName, scope, scenario, latency, status, notFound
+        if (info.notFound) {
+            console.warn(`Missing route: ${info.method} ${info.url}`);
+        } else {
+            myLogger.info(`${info.method} ${info.url} -> ${info.status}`);
+        }
+    },
+    mockRoutes: [...]
+});
+```
+
+### Log Info Object
+
+When using a custom logging function, the `info` object contains:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `method` | String | HTTP method (GET, POST, etc.) |
+| `url` | String | Request URL |
+| `routeName` | String | Matched route name (if found) |
+| `scope` | String | Test scope used |
+| `scenario` | Number/String | Scenario used |
+| `latency` | Number | Applied latency in ms |
+| `status` | Number | HTTP status code |
+| `notFound` | Boolean | True if no route matched |
+
 ## E2E Testing Example
 
 ```javascript
@@ -557,6 +631,7 @@ Version 0.3.0 introduces several improvements while maintaining backward compati
 - Express-style route parameters (`:id`)
 - `created` test scope (201 status)
 - **Presets** - Define named configurations to switch entire experiences at once via `POST /_preset`
+- **Request logging** - Debug mock configuration with `logging: true`, `'verbose'`, or custom function
 
 **Breaking changes:**
 - None - existing code continues to work

--- a/__tests__/mock.test.js
+++ b/__tests__/mock.test.js
@@ -717,4 +717,156 @@ describe('mock-json-api', () => {
             });
         });
     });
+
+    describe('Logging', () => {
+        let consoleSpy;
+
+        beforeEach(() => {
+            consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+        });
+
+        afterEach(() => {
+            consoleSpy.mockRestore();
+        });
+
+        describe('Basic logging (logging: true)', () => {
+            beforeEach(() => {
+                mockApi = mock({
+                    logging: true,
+                    mockRoutes: [{
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        testScenario: 0,
+                        jsonTemplate: '{ "users": [] }'
+                    }]
+                });
+                app = mockApi.createServer();
+            });
+
+            it('should log successful requests', async () => {
+                await request(app).get('/api/users');
+                expect(consoleSpy).toHaveBeenCalled();
+                const logCall = consoleSpy.mock.calls[0][0];
+                expect(logCall).toContain('[mock-json-api]');
+                expect(logCall).toContain('GET');
+                expect(logCall).toContain('/api/users');
+                expect(logCall).toContain('getUsers');
+                expect(logCall).toContain('success');
+                expect(logCall).toContain('200');
+            });
+
+            it('should log not found requests', async () => {
+                await request(app).get('/api/unknown');
+                expect(consoleSpy).toHaveBeenCalled();
+                const logCall = consoleSpy.mock.calls[0][0];
+                expect(logCall).toContain('NOT FOUND');
+            });
+        });
+
+        describe('Verbose logging (logging: "verbose")', () => {
+            beforeEach(() => {
+                mockApi = mock({
+                    logging: 'verbose',
+                    mockRoutes: [{
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        testScenario: 'default',
+                        latency: 50,
+                        jsonTemplate: '{ "users": [] }'
+                    }]
+                });
+                app = mockApi.createServer();
+            });
+
+            it('should log detailed request information', async () => {
+                await request(app).get('/api/users');
+                // Verbose mode logs multiple lines: request line + route + scope + scenario + latency + response
+                expect(consoleSpy.mock.calls.length).toBeGreaterThanOrEqual(5);
+                const calls = consoleSpy.mock.calls.map(c => c[0]);
+                expect(calls.some(c => c.includes('Route: getUsers'))).toBe(true);
+                expect(calls.some(c => c.includes('Scope: success'))).toBe(true);
+                expect(calls.some(c => c.includes('Scenario: default'))).toBe(true);
+                expect(calls.some(c => c.includes('Latency:'))).toBe(true);
+                expect(calls.some(c => c.includes('Response: 200'))).toBe(true);
+            });
+        });
+
+        describe('Custom logging function', () => {
+            it('should call custom logging function with info object', async () => {
+                const customLogger = jest.fn();
+                mockApi = mock({
+                    logging: customLogger,
+                    mockRoutes: [{
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        jsonTemplate: '{ "users": [] }'
+                    }]
+                });
+                app = mockApi.createServer();
+
+                await request(app).get('/api/users');
+
+                expect(customLogger).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        method: 'GET',
+                        url: '/api/users',
+                        routeName: 'getUsers',
+                        scope: 'success',
+                        status: 200
+                    })
+                );
+            });
+
+            it('should pass notFound flag for unmatched routes', async () => {
+                const customLogger = jest.fn();
+                mockApi = mock({
+                    logging: customLogger,
+                    mockRoutes: [{
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        jsonTemplate: '{ "users": [] }'
+                    }]
+                });
+                app = mockApi.createServer();
+
+                await request(app).get('/api/unknown');
+
+                expect(customLogger).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        method: 'GET',
+                        url: '/api/unknown',
+                        notFound: true
+                    })
+                );
+            });
+        });
+
+        describe('Logging disabled (default)', () => {
+            beforeEach(() => {
+                mockApi = mock({
+                    mockRoutes: [{
+                        name: 'getUsers',
+                        mockRoute: '/api/users',
+                        method: 'GET',
+                        testScope: 'success',
+                        jsonTemplate: '{ "users": [] }'
+                    }]
+                });
+                app = mockApi.createServer();
+            });
+
+            it('should not log when logging is disabled', async () => {
+                await request(app).get('/api/users');
+                expect(consoleSpy).not.toHaveBeenCalled();
+            });
+        });
+    });
 });

--- a/mock.js
+++ b/mock.js
@@ -80,6 +80,7 @@ function Mock(config) {
     this.config = config;
     this.presets = config.presets || {};
     this.activePreset = null;
+    this.logging = config.logging || false;
 
     // Store original route configurations for reset
     this.originalRoutes = JSON.parse(JSON.stringify(
@@ -230,6 +231,11 @@ Mock.prototype.registerRoutes = function(req, res, next) {
     }
 
     if (!found) {
+        this._log({
+            method: req.method,
+            url: req.originalUrl,
+            notFound: true
+        });
         if (next) {
             next();
         } else {
@@ -278,6 +284,17 @@ Mock.prototype.registerRoutes = function(req, res, next) {
     }
 
     const response = this._routeResponse(route, req);
+
+    // Log the request
+    this._log({
+        method: req.method,
+        url: req.originalUrl,
+        routeName: route.name,
+        scope: route.testScope,
+        scenario: route.testScenario,
+        latency: latency,
+        status: response.status
+    });
 
     setTimeout(() => {
         res.set('Content-Type', 'application/json');
@@ -419,6 +436,44 @@ Mock.prototype._matchRoutesByPattern = function(pattern) {
     // Exact match
     const route = this.routes.find(r => r.name === pattern);
     return route ? [route] : [];
+};
+
+/**
+ * Log request information
+ * @param {object} info - Log information object
+ */
+Mock.prototype._log = function(info) {
+    if (!this.logging) return;
+
+    // Custom logging function
+    if (typeof this.logging === 'function') {
+        this.logging(info);
+        return;
+    }
+
+    const timestamp = new Date().toISOString();
+    const prefix = '[mock-json-api]';
+
+    if (info.notFound) {
+        console.log(`${prefix} ${info.method} ${info.url} -> NOT FOUND (no matching route)`);
+        return;
+    }
+
+    if (this.logging === 'verbose') {
+        console.log(`${prefix} ${info.method} ${info.url}`);
+        console.log(`  Route: ${info.routeName}`);
+        console.log(`  Scope: ${info.scope}`);
+        console.log(`  Scenario: ${info.scenario}`);
+        if (info.latency > 0) {
+            console.log(`  Latency: ${info.latency}ms`);
+        }
+        console.log(`  Response: ${info.status}`);
+    } else {
+        // Basic logging
+        const scenarioStr = info.scenario !== undefined ? `, scenario: ${info.scenario}` : '';
+        const latencyStr = info.latency > 0 ? ` [${info.latency}ms]` : '';
+        console.log(`${prefix} ${info.method} ${info.url} -> ${info.routeName} (${info.scope}${scenarioStr}) ${info.status}${latencyStr}`);
+    }
 };
 
 Mock.prototype._routeResponse = function(route, req) {


### PR DESCRIPTION
## Summary

- Add optional `logging` config for debugging mock configurations
- Three modes: basic (`true`), verbose (`'verbose'`), and custom function
- Logs matched routes with scope/scenario/status, plus unmatched requests

## Usage

```javascript
// Basic logging
const mockApi = mock({ logging: true, mockRoutes: [...] });
// Output: [mock-json-api] GET /api/users -> getUsers (success, scenario: 0) 200

// Verbose logging
const mockApi = mock({ logging: 'verbose', mockRoutes: [...] });

// Custom logger
const mockApi = mock({ 
    logging: (info) => myLogger.info(info), 
    mockRoutes: [...] 
});
```

## Test plan

- [x] All 46 tests pass (6 new logging tests)
- [x] Basic logging outputs expected format
- [x] Verbose logging outputs detailed info
- [x] Custom function receives info object
- [x] NOT FOUND logged for unmatched routes
- [x] No logging when disabled (default)

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)