### PR TITLE
feat: add TypeScript type definitions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 # Development and test files
 __tests__/
+types.test.ts
 .github/
 
 # Editor and IDE

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Node.js module for creating mock REST APIs with scenario support, perfect for 
 - **Scenario switching** - Easily switch between test scenarios via query params or API
 - **Presets** - Define named configurations to switch entire experiences at once
 - **Request logging** - Debug your mock configuration with built-in logging
+- **TypeScript support** - Full type definitions included for IntelliSense and type safety
 - **State persistence** - Optional JSON file storage simulating a database
 - **State reset** - Reset all state between test runs via `POST /_reset`
 - **CORS enabled** - Works out of the box with frontend dev servers
@@ -619,6 +620,48 @@ app.listen(3001);
 
 However, `createServer()` is recommended as it includes CORS and body parsing automatically.
 
+## TypeScript Support
+
+This package includes TypeScript type definitions. You get full IntelliSense and type checking out of the box:
+
+```typescript
+import mock = require('mock-json-api');
+
+const mockApi = mock({
+    mockRoutes: [
+        {
+            name: 'getUsers',
+            mockRoute: '/api/users',
+            method: 'GET',           // Autocomplete: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+            testScope: 'success',    // Autocomplete: 'success' | 'error' | 'notFound' | ...
+            jsonTemplate: '{ "users": [] }'
+        }
+    ],
+    presets: {
+        'error-mode': {
+            '*': { scope: 'error' }  // Type-checked preset config
+        }
+    }
+});
+
+const app = mockApi.createServer();
+app.listen(3001);
+```
+
+### Available Types
+
+All types are exported under the `mock` namespace:
+
+```typescript
+import mock = require('mock-json-api');
+
+// Use types for your own code
+const routes: mock.MockRoute[] = [...];
+const config: mock.MockConfig = {...};
+const preset: mock.Preset = {...};
+const logInfo: mock.LogInfo = {...};
+```
+
 ## Upgrading to 0.3.0
 
 Version 0.3.0 introduces several improvements while maintaining backward compatibility:
@@ -632,6 +675,7 @@ Version 0.3.0 introduces several improvements while maintaining backward compati
 - `created` test scope (201 status)
 - **Presets** - Define named configurations to switch entire experiences at once via `POST /_preset`
 - **Request logging** - Debug mock configuration with `logging: true`, `'verbose'`, or custom function
+- **TypeScript definitions** - Full type definitions for IntelliSense and type safety
 
 **Breaking changes:**
 - None - existing code continues to work

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,145 @@
+import { Express, Request, Response } from 'express';
+
+declare namespace mock {
+    type TestScope =
+        | 'success'
+        | 'created'
+        | 'noContent'
+        | 'badRequest'
+        | 'unauthorized'
+        | 'forbidden'
+        | 'notFound'
+        | 'timeout'
+        | 'conflict'
+        | 'error';
+
+    type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+    interface MockRoute {
+        /** Unique identifier for the route */
+        name: string;
+        /** URL pattern (supports Express params like `:id` or regex) */
+        mockRoute: string;
+        /** HTTP method */
+        method?: HttpMethod;
+        /** Response behavior / HTTP status category */
+        testScope?: TestScope;
+        /** Which scenario template to use (index, name, or function) */
+        testScenario?: number | string | ((req: Request) => number | string);
+        /** Response template(s) - string, function, or array of scenarios */
+        jsonTemplate?: string | ((req: Request) => string) | Array<((req: Request) => string) | Record<string, (req: Request) => string>>;
+        /** Response delay in ms (e.g., 300 or "200-500" for random range) */
+        latency?: number | string;
+        /** Custom error response body */
+        errorBody?: any;
+        /** Custom data for dummy-json templates */
+        data?: Record<string, any>;
+        /** Custom dummy-json helper functions */
+        helpers?: Record<string, (...args: any[]) => any>;
+    }
+
+    interface PresetRouteConfig {
+        /** Scenario to use for this route */
+        scenario?: number | string;
+        /** Test scope to use for this route */
+        scope?: TestScope;
+        /** Latency to apply to this route */
+        latency?: number | string;
+    }
+
+    interface Preset {
+        /** Route name or pattern ('*' for all, 'prefix*' for prefix match) mapped to config */
+        [routeNameOrPattern: string]: PresetRouteConfig;
+    }
+
+    interface LogInfo {
+        /** HTTP method */
+        method: string;
+        /** Request URL */
+        url: string;
+        /** Matched route name (if found) */
+        routeName?: string;
+        /** Test scope used */
+        scope?: TestScope;
+        /** Scenario used */
+        scenario?: number | string;
+        /** Applied latency in ms */
+        latency?: number;
+        /** HTTP status code */
+        status?: number;
+        /** True if no route matched */
+        notFound?: boolean;
+    }
+
+    type LoggingOption = boolean | 'verbose' | ((info: LogInfo) => void);
+
+    interface CorsOptions {
+        origin?: string | string[] | boolean;
+        methods?: string | string[];
+        allowedHeaders?: string | string[];
+        exposedHeaders?: string | string[];
+        credentials?: boolean;
+        maxAge?: number;
+    }
+
+    interface MockConfig {
+        /** Array of route configurations (required) */
+        mockRoutes: MockRoute[];
+        /** File path for data persistence */
+        jsonStore?: string;
+        /** CORS settings (default: enabled) */
+        cors?: boolean | CorsOptions;
+        /** Named preset configurations */
+        presets?: Record<string, Preset>;
+        /** Request logging option */
+        logging?: LoggingOption;
+    }
+
+    interface DataStore {
+        get(key: string): any;
+        set(key: string, value: any): any;
+        clear(): void;
+    }
+
+    interface MockInstance {
+        /** Data store instance */
+        store: DataStore;
+        /** Array of configured routes */
+        routes: MockRoute[];
+        /** Configuration object */
+        config: MockConfig;
+        /** Defined presets */
+        presets: Record<string, Preset>;
+        /** Currently active preset name (null if none) */
+        activePreset: string | null;
+        /** Logging configuration */
+        logging: LoggingOption;
+
+        /** Create an Express app with all middleware and routes configured */
+        createServer(): Express;
+
+        /** Reset all state to initial configuration */
+        reset(): void;
+
+        /** Route matching middleware */
+        registerRoutes(req: Request, res: Response, next?: () => void): void;
+
+        /** Set route scenario via API */
+        setRouteScenario(req: Request, res: Response): void;
+
+        /** Get available presets */
+        getPresets(req: Request, res: Response): void;
+
+        /** Activate a preset */
+        setPreset(req: Request, res: Response): void;
+    }
+}
+
+/**
+ * Create a new mock API instance
+ * @param config - Configuration object with routes, presets, and options
+ * @returns MockInstance with createServer() method
+ */
+declare function mock(config: mock.MockConfig): mock.MockInstance;
+
+export = mock;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "path-to-regexp": "^6.3.0"
       },
       "devDependencies": {
+        "@types/express": "^4.17.21",
         "jest": "^29.7.0",
-        "supertest": "^7.0.0"
+        "supertest": "^7.0.0",
+        "typescript": "^5.3.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1033,6 +1035,53 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1042,6 +1091,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1070,6 +1126,13 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.2.tgz",
@@ -1078,6 +1141,53 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4718,6 +4828,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0",
   "description": "Mock JSON API server for Node.js with scenario support",
   "main": "mock.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/jeffflater/mock-json-api.git"
@@ -31,11 +32,14 @@
     "path-to-regexp": "^6.3.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "jest": "^29.7.0",
-    "supertest": "^7.0.0"
+    "supertest": "^7.0.0",
+    "typescript": "^5.3.0"
   },
   "scripts": {
     "test": "jest --testPathPattern=__tests__",
-    "test:watch": "jest --watch --testPathPattern=__tests__"
+    "test:watch": "jest --watch --testPathPattern=__tests__",
+    "test:types": "tsc types.test.ts --noEmit --esModuleInterop --skipLibCheck"
   }
 }

--- a/types.test.ts
+++ b/types.test.ts
@@ -1,0 +1,105 @@
+// TypeScript compilation test - verifies type definitions are correct
+// This file is only compiled, not executed
+
+import mock = require('./index');
+
+// Test basic config
+const basicApi = mock({
+    mockRoutes: [
+        {
+            name: 'getUsers',
+            mockRoute: '/api/users',
+            method: 'GET',
+            testScope: 'success',
+            jsonTemplate: '{ "users": [] }'
+        }
+    ]
+});
+
+// Test full config with all options
+const fullApi = mock({
+    jsonStore: './data.json',
+    cors: {
+        origin: 'http://localhost:3000',
+        credentials: true
+    },
+    logging: 'verbose',
+    presets: {
+        'error-mode': {
+            '*': { scope: 'error' }
+        },
+        'slow-mode': {
+            'getUsers': { latency: 1000, scenario: 'empty' }
+        }
+    },
+    mockRoutes: [
+        {
+            name: 'getUsers',
+            mockRoute: '/api/users',
+            method: 'GET',
+            testScope: 'success',
+            testScenario: 0,
+            latency: '100-500',
+            jsonTemplate: [
+                (req) => JSON.stringify({ users: [], query: req.query }),
+                { 'empty': (req) => '{ "users": [] }' }
+            ],
+            data: { customField: 'value' },
+            helpers: { customHelper: () => 'result' }
+        },
+        {
+            name: 'getUser',
+            mockRoute: '/api/users/:id',
+            method: 'GET',
+            testScope: 'success',
+            testScenario: (req) => req.params.id === '0' ? 'notFound' : 0,
+            jsonTemplate: (req) => JSON.stringify({ id: req.params.id })
+        },
+        {
+            name: 'createUser',
+            mockRoute: '/api/users',
+            method: 'POST',
+            testScope: 'created',
+            errorBody: { error: 'Custom error' }
+        }
+    ]
+});
+
+// Test custom logging function
+const customLogApi = mock({
+    logging: (info) => {
+        console.log(info.method, info.url, info.status, info.notFound);
+    },
+    mockRoutes: [{ name: 'test', mockRoute: '/test', testScope: 'success', jsonTemplate: '{}' }]
+});
+
+// Test createServer returns Express app
+const app = basicApi.createServer();
+
+// Test instance properties
+const routes: mock.MockRoute[] = basicApi.routes;
+const activePreset: string | null = basicApi.activePreset;
+const presets: Record<string, mock.Preset> = basicApi.presets;
+
+// Test methods exist
+basicApi.reset();
+
+// Test type exports are accessible
+type Scope = mock.TestScope;
+type Route = mock.MockRoute;
+type Config = mock.MockConfig;
+type Instance = mock.MockInstance;
+type Log = mock.LogInfo;
+
+const scope: Scope = 'success';
+const logInfo: Log = {
+    method: 'GET',
+    url: '/api/test',
+    routeName: 'test',
+    scope: 'success',
+    scenario: 0,
+    latency: 100,
+    status: 200
+};
+
+console.log('Types are valid!');


### PR DESCRIPTION
## Summary

- Add TypeScript type definitions (`index.d.ts`) for full IntelliSense and type safety
- No changes to JavaScript implementation - types only

## Types included

- `MockConfig`, `MockRoute`, `MockInstance` - main interfaces
- `TestScope` - union type for all valid scopes
- `HttpMethod` - union type for HTTP methods  
- `Preset`, `PresetRouteConfig` - preset configuration types
- `LogInfo`, `LoggingOption` - logging types

## Usage

```typescript
import mock = require('mock-json-api');

const api = mock({
    mockRoutes: [{
        name: 'test',
        testScope: 'success',  // ← autocomplete works
        // ...
    }]
});

// Types are also accessible
const routes: mock.MockRoute[] = [...];
```

## Test plan

- [x] All 46 Jest tests pass
- [x] TypeScript definitions compile (`npm run test:types`)
- [x] Type test file validates all interfaces work correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)