### PR TITLE
feat: add MCP server for AI-assisted mock API management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,255 @@
+# AI Agent Installation Guide
+
+> **For AI Assistants**: This document provides instructions for installing and configuring mock-json-api when a user asks you to set it up.
+
+## Quick Reference
+
+| Component | Purpose | Installation |
+|-----------|---------|--------------|
+| **mock-json-api** | Node.js library for creating mock REST APIs | `npm install mock-json-api` |
+| **MCP Server** | Control mock APIs via AI assistants (Claude, etc.) | See MCP Setup below |
+
+---
+
+## Installation Instructions
+
+### Step 1: Install the Mock Server Library
+
+```bash
+npm install mock-json-api
+```
+
+Or add to package.json:
+```json
+{
+  "dependencies": {
+    "mock-json-api": "^0.5.0"
+  }
+}
+```
+
+### Step 2: Create a Basic Mock Server
+
+Create a file (e.g., `mock-server.js`):
+
+```javascript
+const mock = require('mock-json-api');
+
+const mockApi = mock({
+  mockRoutes: [
+    {
+      name: 'getUsers',
+      mockRoute: '/api/users',
+      method: 'GET',
+      testScope: 'success',
+      jsonTemplate: '{"users": [{"id": 1, "name": "{{firstName}}"}]}'
+    }
+  ]
+});
+
+const app = mockApi.createServer();
+app.listen(3001, () => console.log('Mock API running on http://localhost:3001'));
+```
+
+Run it:
+```bash
+node mock-server.js
+```
+
+---
+
+## MCP Server Setup (For AI Control)
+
+The MCP server allows AI assistants to create and control mock APIs dynamically.
+
+### Step 1: Install MCP Server Dependencies
+
+```bash
+cd /path/to/mock-json-api/mcp-server
+npm install
+```
+
+### Step 2: Configure Claude Desktop
+
+Add to Claude Desktop config file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Linux**: `~/.config/claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "mock-json-api": {
+      "command": "node",
+      "args": ["/absolute/path/to/mock-json-api/mcp-server/index.js"]
+    }
+  }
+}
+```
+
+### Step 3: Restart Claude Desktop
+
+The MCP tools will be available after restart.
+
+---
+
+## MCP Tools Reference
+
+Once configured, these tools are available:
+
+### Server Management
+| Tool | Description |
+|------|-------------|
+| `create_mock_server` | Create a mock server with routes |
+| `start_server` | Start server on a port |
+| `stop_server` | Stop a running server |
+| `destroy_server` | Stop and remove server |
+| `list_servers` | List all servers |
+| `get_server_info` | Get server details |
+| `reset_server` | Reset to initial state |
+
+### Route Management
+| Tool | Description |
+|------|-------------|
+| `add_route` | Add a route to a server |
+| `update_route` | Update route configuration |
+| `delete_route` | Remove a route |
+| `set_scenario` | Change route's response behavior |
+
+### Preset Management
+| Tool | Description |
+|------|-------------|
+| `list_presets` | List available presets |
+| `activate_preset` | Switch multiple routes at once |
+| `add_preset` | Create a new preset |
+
+### Testing
+| Tool | Description |
+|------|-------------|
+| `test_route` | Make HTTP request to mock route |
+
+---
+
+## Example: Create a CRUD API via MCP
+
+When a user asks to create a mock API, use these tools:
+
+```javascript
+// 1. Create the server
+create_mock_server({
+  serverId: "my-api",
+  routes: [
+    {
+      name: "listUsers",
+      mockRoute: "/api/users",
+      method: "GET",
+      testScope: "success",
+      jsonTemplate: '{"users": [{{#repeat 3}}{"id": {{@index}}, "name": "{{firstName}}"}{{/repeat}}]}'
+    },
+    {
+      name: "getUser",
+      mockRoute: "/api/users/:id",
+      method: "GET",
+      testScope: "success",
+      jsonTemplate: '{"id": "{{request.params.id}}", "name": "{{firstName}}"}'
+    },
+    {
+      name: "createUser",
+      mockRoute: "/api/users",
+      method: "POST",
+      testScope: "created",
+      jsonTemplate: '{"id": {{int 100 999}}, "name": "{{request.body.name}}"}'
+    },
+    {
+      name: "deleteUser",
+      mockRoute: "/api/users/:id",
+      method: "DELETE",
+      testScope: "noContent"
+    }
+  ],
+  presets: {
+    "all-errors": { "*": { "scope": "error" } },
+    "slow-network": { "*": { "latency": "1000-3000" } }
+  }
+})
+
+// 2. Start the server
+start_server({ serverId: "my-api", port: 3001 })
+
+// 3. Test a route
+test_route({ serverId: "my-api", path: "/api/users", method: "GET" })
+```
+
+---
+
+## Test Scopes (HTTP Status Codes)
+
+| Scope | Status | Use Case |
+|-------|--------|----------|
+| `success` | 200 | Normal successful response |
+| `created` | 201 | Resource created (POST) |
+| `noContent` | 204 | Success with no body (DELETE) |
+| `badRequest` | 400 | Invalid request data |
+| `unauthorized` | 401 | Authentication required |
+| `forbidden` | 403 | Permission denied |
+| `notFound` | 404 | Resource not found |
+| `timeout` | 408 | Request timeout |
+| `conflict` | 409 | Resource conflict |
+| `error` | 500 | Server error |
+
+---
+
+## JSON Template Syntax (dummy-json)
+
+Templates use [dummy-json](https://github.com/webroo/dummy-json) helpers:
+
+```javascript
+// Random data
+'{"id": {{int 1 100}}, "name": "{{firstName}} {{lastName}}"}'
+
+// Repeat data
+'{"items": [{{#repeat 5}}{"id": {{@index}}}{{/repeat}}]}'
+
+// Request data access
+'{"echo": "{{request.body.message}}", "userId": "{{request.params.id}}"}'
+
+// Available helpers: firstName, lastName, email, company,
+// int, float, boolean, date, time, and more
+```
+
+---
+
+## Troubleshooting
+
+### MCP Server Not Connecting
+1. Verify the path in claude_desktop_config.json is absolute
+2. Ensure node is in PATH
+3. Check MCP server starts manually: `node /path/to/mcp-server/index.js`
+
+### Routes Not Matching
+1. Parameterized routes (`:id`) are matched before regex routes
+2. Routes are case-insensitive
+3. Use `get_server_info` to verify route configuration
+
+### Port Already in Use
+1. Use a different port (1024-65535)
+2. Stop other servers: `stop_server({ serverId: "..." })`
+3. Check: `lsof -i :PORT` (macOS/Linux) or `netstat -ano | findstr :PORT` (Windows)
+
+---
+
+## Project Structure
+
+```
+mock-json-api/
+├── mock.js              # Main library
+├── index.d.ts           # TypeScript definitions
+├── package.json         # Library package
+├── README.md            # Library documentation
+├── AGENTS.md            # This file (AI installation guide)
+└── mcp-server/
+    ├── index.js         # MCP server implementation
+    ├── package.json     # MCP server package
+    └── README.md        # MCP server documentation
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Node.js module for creating mock REST APIs with scenario support, perfect for 
 - **Flexible routing** - Regex patterns or Express-style params (`:id`)
 - **Dummy data generation** - Uses [dummy-json](https://github.com/webroo/dummy-json) for realistic test data
 - **Latency simulation** - Add delays to simulate network conditions
+- **MCP Server** - Control mock APIs via AI assistants using Model Context Protocol
 
 ## Installation
 
@@ -682,6 +683,53 @@ Version 0.3.0 introduces several improvements while maintaining backward compati
 
 **Deprecated:**
 - Using `registerRoutes` directly without body parsing middleware
+
+## MCP Server
+
+An MCP (Model Context Protocol) server is included for controlling mock APIs via AI assistants like Claude.
+
+### Installation
+
+```bash
+cd mcp-server
+npm install
+```
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "mock-json-api": {
+      "command": "node",
+      "args": ["/path/to/mock-json-api/mcp-server/index.js"]
+    }
+  }
+}
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_mock_server` | Create a mock server with routes |
+| `start_server` | Start listening on a port |
+| `stop_server` | Stop a running server |
+| `list_servers` | List all server instances |
+| `get_server_info` | Get server details |
+| `add_route` | Add a route to a server |
+| `update_route` | Update route configuration |
+| `delete_route` | Delete a route |
+| `set_scenario` | Change route scenario/scope |
+| `list_presets` | List available presets |
+| `activate_preset` | Activate a preset |
+| `add_preset` | Add a new preset |
+| `reset_server` | Reset server state |
+| `test_route` | Test a route and get response |
+
+See [mcp-server/README.md](mcp-server/README.md) for full documentation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://badge.fury.io/js/mock-json-api.svg)](https://www.npmjs.com/package/mock-json-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+> **🤖 AI Agents**: If you're an AI assistant helping a user install or configure this project, read **[AGENTS.md](AGENTS.md)** for step-by-step installation instructions, MCP server setup, and tool references.
+
 A Node.js module for creating mock REST APIs with scenario support, perfect for frontend development and E2E testing.
 
 ## Features

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -9,19 +9,35 @@ cd mcp-server
 npm install
 ```
 
-## Usage with Claude Desktop
+## Configuration
 
-Add to your Claude Desktop configuration (`~/.config/claude/claude_desktop_config.json` on Linux or `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+### Claude Desktop
+
+Add to your Claude Desktop configuration:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Linux**: `~/.config/claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
 ```json
 {
   "mcpServers": {
     "mock-json-api": {
       "command": "node",
-      "args": ["/path/to/mock-json-api/mcp-server/index.js"]
+      "args": ["/absolute/path/to/mock-json-api/mcp-server/index.js"]
     }
   }
 }
+```
+
+Restart Claude Desktop after configuration.
+
+### Other MCP Clients
+
+The server uses stdio transport. Start with:
+
+```bash
+node /path/to/mcp-server/index.js
 ```
 
 ## Available Tools
@@ -31,10 +47,11 @@ Add to your Claude Desktop configuration (`~/.config/claude/claude_desktop_confi
 | Tool | Description |
 |------|-------------|
 | `create_mock_server` | Create a new mock API server with routes configuration |
-| `start_server` | Start a server listening on a port |
-| `stop_server` | Stop a running server |
+| `start_server` | Start a server listening on a port (1024-65535) |
+| `stop_server` | Stop a running server gracefully |
+| `destroy_server` | Stop and completely remove a server instance |
 | `list_servers` | List all server instances and their status |
-| `get_server_info` | Get detailed server information |
+| `get_server_info` | Get detailed server information including routes |
 | `reset_server` | Reset server state to initial configuration |
 
 ### Route Management
@@ -42,7 +59,7 @@ Add to your Claude Desktop configuration (`~/.config/claude/claude_desktop_confi
 | Tool | Description |
 |------|-------------|
 | `add_route` | Add a new route to an existing server |
-| `update_route` | Update an existing route configuration |
+| `update_route` | Update an existing route's configuration |
 | `delete_route` | Delete a route from a server |
 | `set_scenario` | Change a route's scenario and/or scope |
 
@@ -50,22 +67,21 @@ Add to your Claude Desktop configuration (`~/.config/claude/claude_desktop_confi
 
 | Tool | Description |
 |------|-------------|
-| `list_presets` | List available presets |
-| `activate_preset` | Activate a preset to switch multiple routes |
+| `list_presets` | List available presets for a server |
+| `activate_preset` | Activate a preset (use "default" to reset) |
 | `add_preset` | Add a new preset configuration |
 
 ### Testing
 
 | Tool | Description |
 |------|-------------|
-| `test_route` | Make a test request to a mock route |
+| `test_route` | Make a test HTTP request and return the response |
 
-## Example Usage
+## Usage Examples
 
 ### Create a Mock Server
 
 ```javascript
-// Via AI assistant
 create_mock_server({
   serverId: "my-api",
   routes: [
@@ -81,7 +97,7 @@ create_mock_server({
       mockRoute: "/api/users/:id",
       method: "GET",
       testScope: "success",
-      jsonTemplate: '{"id": {{request.params.id}}, "name": "{{firstName}}"}'
+      jsonTemplate: '{"id": "{{request.params.id}}", "name": "{{firstName}}"}'
     },
     {
       name: "createUser",
@@ -92,12 +108,8 @@ create_mock_server({
     }
   ],
   presets: {
-    "error-mode": {
-      "*": { "scope": "error" }
-    },
-    "slow-mode": {
-      "*": { "latency": "1000-3000" }
-    }
+    "error-mode": { "*": { "scope": "error" } },
+    "slow-mode": { "*": { "latency": "1000-3000" } }
   }
 })
 ```
@@ -120,7 +132,7 @@ test_route({
   path: "/api/users",
   method: "GET"
 })
-// Returns the mock response
+// Returns the mock response with status and body
 ```
 
 ### Switch to Error Mode
@@ -144,9 +156,22 @@ set_scenario({
 // getUsers now returns 404
 ```
 
-## Test Scopes
+### Add Route Dynamically
 
-The following scopes are available for simulating different HTTP responses:
+```javascript
+add_route({
+  serverId: "my-api",
+  route: {
+    name: "updateUser",
+    mockRoute: "/api/users/:id",
+    method: "PUT",
+    testScope: "success",
+    jsonTemplate: '{"id": "{{request.params.id}}", "updated": true}'
+  }
+})
+```
+
+## Test Scopes
 
 | Scope | HTTP Status | Description |
 |-------|-------------|-------------|
@@ -173,15 +198,69 @@ The mock server uses [dummy-json](https://github.com/webroo/dummy-json) for gene
 '{"users": [{{#repeat 5}}{"id": {{@index}}}{{/repeat}}]}'
 
 // Use request data
-'{"echo": "{{request.body.message}}", "userId": {{request.params.id}}}'
+'{"echo": "{{request.body.message}}", "userId": "{{request.params.id}}"}'
 ```
 
 ## Resources
 
-The MCP server also exposes resources that can be read:
+The MCP server exposes resources for each server:
 
-- `mock-server://{serverId}/config` - Server configuration and status
-- `mock-server://{serverId}/routes` - Route definitions
+| URI Pattern | Description |
+|-------------|-------------|
+| `mock-server://{serverId}/config` | Server configuration and status |
+| `mock-server://{serverId}/routes` | Route definitions |
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Maximum servers | 100 |
+| Maximum routes per server | 1000 |
+| Server ID length | 100 characters |
+| Server shutdown timeout | 30 seconds |
+| Valid port range | 1024-65535 |
+
+## Error Handling
+
+All tools return standardized responses:
+
+**Success:**
+```json
+{
+  "success": true,
+  "message": "Operation completed",
+  "...": "additional data"
+}
+```
+
+**Error:**
+```json
+{
+  "error": true,
+  "message": "Error description"
+}
+```
+
+## Graceful Shutdown
+
+The MCP server handles SIGTERM and SIGINT signals, gracefully stopping all running mock servers before exiting.
+
+## Troubleshooting
+
+### Server won't start
+- Check if the port is already in use
+- Ensure port is in valid range (1024-65535)
+- Use `list_servers` to check existing servers
+
+### Routes not matching
+- Parameterized routes (`:id`) are matched before regex routes
+- Route matching is case-insensitive
+- Use `get_server_info` to verify route configuration
+
+### MCP connection issues
+- Verify the path in claude_desktop_config.json is absolute
+- Ensure Node.js is installed and in PATH
+- Check server starts manually: `node index.js`
 
 ## License
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,188 @@
+# mock-json-api MCP Server
+
+An MCP (Model Context Protocol) server that provides tools to create, manage, and control mock REST API servers via AI assistants.
+
+## Installation
+
+```bash
+cd mcp-server
+npm install
+```
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop configuration (`~/.config/claude/claude_desktop_config.json` on Linux or `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "mock-json-api": {
+      "command": "node",
+      "args": ["/path/to/mock-json-api/mcp-server/index.js"]
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Server Lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `create_mock_server` | Create a new mock API server with routes configuration |
+| `start_server` | Start a server listening on a port |
+| `stop_server` | Stop a running server |
+| `list_servers` | List all server instances and their status |
+| `get_server_info` | Get detailed server information |
+| `reset_server` | Reset server state to initial configuration |
+
+### Route Management
+
+| Tool | Description |
+|------|-------------|
+| `add_route` | Add a new route to an existing server |
+| `update_route` | Update an existing route configuration |
+| `delete_route` | Delete a route from a server |
+| `set_scenario` | Change a route's scenario and/or scope |
+
+### Preset Management
+
+| Tool | Description |
+|------|-------------|
+| `list_presets` | List available presets |
+| `activate_preset` | Activate a preset to switch multiple routes |
+| `add_preset` | Add a new preset configuration |
+
+### Testing
+
+| Tool | Description |
+|------|-------------|
+| `test_route` | Make a test request to a mock route |
+
+## Example Usage
+
+### Create a Mock Server
+
+```javascript
+// Via AI assistant
+create_mock_server({
+  serverId: "my-api",
+  routes: [
+    {
+      name: "getUsers",
+      mockRoute: "/api/users",
+      method: "GET",
+      testScope: "success",
+      jsonTemplate: '{"users": [{"id": 1, "name": "John"}, {"id": 2, "name": "Jane"}]}'
+    },
+    {
+      name: "getUser",
+      mockRoute: "/api/users/:id",
+      method: "GET",
+      testScope: "success",
+      jsonTemplate: '{"id": {{request.params.id}}, "name": "{{firstName}}"}'
+    },
+    {
+      name: "createUser",
+      mockRoute: "/api/users",
+      method: "POST",
+      testScope: "created",
+      jsonTemplate: '{"id": {{int 100 999}}, "name": "{{request.body.name}}"}'
+    }
+  ],
+  presets: {
+    "error-mode": {
+      "*": { "scope": "error" }
+    },
+    "slow-mode": {
+      "*": { "latency": "1000-3000" }
+    }
+  }
+})
+```
+
+### Start the Server
+
+```javascript
+start_server({
+  serverId: "my-api",
+  port: 3001
+})
+// Returns: { baseUrl: "http://localhost:3001" }
+```
+
+### Test a Route
+
+```javascript
+test_route({
+  serverId: "my-api",
+  path: "/api/users",
+  method: "GET"
+})
+// Returns the mock response
+```
+
+### Switch to Error Mode
+
+```javascript
+activate_preset({
+  serverId: "my-api",
+  presetName: "error-mode"
+})
+// All routes now return 500 errors
+```
+
+### Test Individual Route Scenario
+
+```javascript
+set_scenario({
+  serverId: "my-api",
+  routeName: "getUsers",
+  scope: "notFound"
+})
+// getUsers now returns 404
+```
+
+## Test Scopes
+
+The following scopes are available for simulating different HTTP responses:
+
+| Scope | HTTP Status | Description |
+|-------|-------------|-------------|
+| `success` | 200 | OK - returns jsonTemplate |
+| `created` | 201 | Created |
+| `noContent` | 204 | No Content |
+| `badRequest` | 400 | Bad Request |
+| `unauthorized` | 401 | Unauthorized |
+| `forbidden` | 403 | Forbidden |
+| `notFound` | 404 | Not Found |
+| `timeout` | 408 | Request Timeout |
+| `conflict` | 409 | Conflict |
+| `error` | 500 | Internal Server Error |
+
+## JSON Template Syntax
+
+The mock server uses [dummy-json](https://github.com/webroo/dummy-json) for generating dynamic responses:
+
+```javascript
+// Random data
+'{"id": {{int 1 100}}, "name": "{{firstName}} {{lastName}}"}'
+
+// Repeat data
+'{"users": [{{#repeat 5}}{"id": {{@index}}}{{/repeat}}]}'
+
+// Use request data
+'{"echo": "{{request.body.message}}", "userId": {{request.params.id}}}'
+```
+
+## Resources
+
+The MCP server also exposes resources that can be read:
+
+- `mock-server://{serverId}/config` - Server configuration and status
+- `mock-server://{serverId}/routes` - Route definitions
+
+## License
+
+MIT

--- a/mcp-server/__tests__/tools.test.js
+++ b/mcp-server/__tests__/tools.test.js
@@ -1,0 +1,313 @@
+/**
+ * Tests for mock-json-api MCP Server
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const mock = require('mock-json-api');
+
+describe('mock-json-api integration', () => {
+  let mockInstance;
+  let app;
+  let server;
+
+  beforeEach(() => {
+    mockInstance = mock({
+      mockRoutes: [
+        {
+          name: 'getUsers',
+          mockRoute: '/api/users',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{"users": [{"id": 1, "name": "Test"}]}'
+        },
+        {
+          name: 'getUser',
+          mockRoute: '/api/users/:id',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{"id": "test", "name": "Test User"}'
+        }
+      ],
+      presets: {
+        'error-mode': {
+          '*': { scope: 'error' }
+        }
+      }
+    });
+    app = mockInstance.createServer();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise(resolve => server.close(resolve));
+      server = null;
+    }
+  });
+
+  it('should create a mock instance with routes', () => {
+    assert.strictEqual(mockInstance.routes.length, 2);
+    assert.strictEqual(mockInstance.routes[0].name, 'getUsers');
+    assert.strictEqual(mockInstance.routes[1].name, 'getUser');
+  });
+
+  it('should have presets configured', () => {
+    assert.ok(mockInstance.presets['error-mode']);
+    assert.deepStrictEqual(mockInstance.presets['error-mode']['*'], { scope: 'error' });
+  });
+
+  it('should reset state correctly', () => {
+    mockInstance.routes[0].testScope = 'error';
+    mockInstance.activePreset = 'error-mode';
+
+    mockInstance.reset();
+
+    assert.strictEqual(mockInstance.routes[0].testScope, 'success');
+    assert.strictEqual(mockInstance.activePreset, null);
+  });
+
+  it('should start and respond to requests', async () => {
+    const port = 3999 + Math.floor(Math.random() * 1000);
+
+    server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    const response = await fetch(`http://localhost:${port}/api/users`);
+    assert.strictEqual(response.status, 200);
+
+    const data = await response.json();
+    assert.ok(data.users);
+    assert.strictEqual(data.users.length, 1);
+  });
+
+  it('should handle parameterized routes', async () => {
+    const port = 3999 + Math.floor(Math.random() * 1000);
+
+    server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    const response = await fetch(`http://localhost:${port}/api/users/123`);
+    assert.strictEqual(response.status, 200);
+  });
+
+  it('should return 404 for unknown routes', async () => {
+    const port = 3999 + Math.floor(Math.random() * 1000);
+
+    server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    const response = await fetch(`http://localhost:${port}/unknown`);
+    assert.strictEqual(response.status, 404);
+  });
+
+  it('should respond to reset endpoint', async () => {
+    const port = 3999 + Math.floor(Math.random() * 1000);
+
+    server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    const response = await fetch(`http://localhost:${port}/_reset`, {
+      method: 'POST'
+    });
+
+    assert.strictEqual(response.status, 200);
+    const data = await response.json();
+    assert.strictEqual(data.success, true);
+  });
+});
+
+describe('route matching', () => {
+  it('should match exact routes', () => {
+    const mockInstance = mock({
+      mockRoutes: [
+        {
+          name: 'exactRoute',
+          mockRoute: '^/api/exact$',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{}'
+        }
+      ]
+    });
+
+    assert.strictEqual(mockInstance.routes.length, 1);
+    assert.strictEqual(mockInstance.routes[0]._isParamRoute, false);
+  });
+
+  it('should compile parameterized route matchers', () => {
+    const mockInstance = mock({
+      mockRoutes: [
+        {
+          name: 'paramRoute',
+          mockRoute: '/api/users/:id',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{}'
+        }
+      ]
+    });
+
+    assert.strictEqual(mockInstance.routes[0]._isParamRoute, true);
+    assert.ok(mockInstance.routes[0]._matcher);
+  });
+});
+
+describe('test scopes', () => {
+  const scopes = [
+    { scope: 'success', status: 200 },
+    { scope: 'created', status: 201 },
+    { scope: 'noContent', status: 204 },
+    { scope: 'badRequest', status: 400 },
+    { scope: 'unauthorized', status: 401 },
+    { scope: 'forbidden', status: 403 },
+    { scope: 'notFound', status: 404 },
+    { scope: 'timeout', status: 408 },
+    { scope: 'conflict', status: 409 },
+    { scope: 'error', status: 500 },
+  ];
+
+  for (const { scope, status } of scopes) {
+    it(`should return ${status} for ${scope} scope`, async () => {
+      const mockInstance = mock({
+        mockRoutes: [
+          {
+            name: 'testRoute',
+            mockRoute: '/test',
+            method: 'GET',
+            testScope: scope,
+            jsonTemplate: '{}'
+          }
+        ]
+      });
+
+      const app = mockInstance.createServer();
+      const port = 4999 + Math.floor(Math.random() * 1000);
+
+      const server = await new Promise((resolve, reject) => {
+        const s = app.listen(port, () => resolve(s));
+        s.on('error', reject);
+      });
+
+      try {
+        const response = await fetch(`http://localhost:${port}/test`);
+        assert.strictEqual(response.status, status, `Expected ${status} for scope ${scope}`);
+      } finally {
+        await new Promise(resolve => server.close(resolve));
+      }
+    });
+  }
+});
+
+describe('presets', () => {
+  it('should activate preset and update routes', async () => {
+    const mockInstance = mock({
+      mockRoutes: [
+        {
+          name: 'route1',
+          mockRoute: '/api/route1',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{}'
+        },
+        {
+          name: 'route2',
+          mockRoute: '/api/route2',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{}'
+        }
+      ],
+      presets: {
+        'all-errors': {
+          '*': { scope: 'error' }
+        }
+      }
+    });
+
+    const app = mockInstance.createServer();
+    const port = 5999 + Math.floor(Math.random() * 1000);
+
+    const server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    try {
+      // Activate preset
+      const presetResponse = await fetch(`http://localhost:${port}/_preset`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'all-errors' })
+      });
+
+      assert.strictEqual(presetResponse.status, 200);
+
+      // Check routes return errors
+      const route1Response = await fetch(`http://localhost:${port}/api/route1`);
+      assert.strictEqual(route1Response.status, 500);
+
+      const route2Response = await fetch(`http://localhost:${port}/api/route2`);
+      assert.strictEqual(route2Response.status, 500);
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+
+  it('should reset to default when preset is null', async () => {
+    const mockInstance = mock({
+      mockRoutes: [
+        {
+          name: 'route1',
+          mockRoute: '/api/route1',
+          method: 'GET',
+          testScope: 'success',
+          jsonTemplate: '{}'
+        }
+      ],
+      presets: {
+        'error-mode': { '*': { scope: 'error' } }
+      }
+    });
+
+    const app = mockInstance.createServer();
+    const port = 6999 + Math.floor(Math.random() * 1000);
+
+    const server = await new Promise((resolve, reject) => {
+      const s = app.listen(port, () => resolve(s));
+      s.on('error', reject);
+    });
+
+    try {
+      // Activate error preset
+      await fetch(`http://localhost:${port}/_preset`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'error-mode' })
+      });
+
+      // Reset to default
+      await fetch(`http://localhost:${port}/_preset`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: null })
+      });
+
+      // Should be back to success
+      const response = await fetch(`http://localhost:${port}/api/route1`);
+      assert.strictEqual(response.status, 200);
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,0 +1,1022 @@
+#!/usr/bin/env node
+
+/**
+ * MCP Server for mock-json-api
+ *
+ * Provides tools to create, manage, and control mock REST API servers
+ * via the Model Context Protocol.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import mock from 'mock-json-api';
+
+// Store for active mock server instances
+const servers = new Map();
+
+// Server configuration
+const server = new Server(
+  {
+    name: 'mock-json-api-mcp-server',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+      resources: {},
+    },
+  }
+);
+
+// Define available tools
+const tools = [
+  {
+    name: 'create_mock_server',
+    description: 'Create a new mock API server instance with routes configuration. Returns a server ID that can be used to manage the server.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'Unique identifier for this mock server instance',
+        },
+        routes: {
+          type: 'array',
+          description: 'Array of route configurations',
+          items: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Unique name for the route',
+              },
+              mockRoute: {
+                type: 'string',
+                description: 'URL pattern to match (e.g., "/api/users" or "/api/users/:id")',
+              },
+              method: {
+                type: 'string',
+                enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+                description: 'HTTP method',
+              },
+              testScope: {
+                type: 'string',
+                enum: ['success', 'created', 'noContent', 'badRequest', 'unauthorized', 'forbidden', 'notFound', 'timeout', 'conflict', 'error'],
+                description: 'Response scope determining HTTP status code',
+              },
+              jsonTemplate: {
+                type: 'string',
+                description: 'JSON response template (supports dummy-json syntax for data generation)',
+              },
+              latency: {
+                type: ['number', 'string'],
+                description: 'Response delay in ms (number) or range (e.g., "100-500")',
+              },
+            },
+            required: ['name', 'mockRoute', 'method'],
+          },
+        },
+        presets: {
+          type: 'object',
+          description: 'Named presets for switching multiple routes at once',
+          additionalProperties: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                scenario: { type: ['string', 'number'] },
+                scope: { type: 'string' },
+                latency: { type: ['number', 'string'] },
+              },
+            },
+          },
+        },
+        jsonStore: {
+          type: 'string',
+          description: 'Path to JSON file for persisting mock data',
+        },
+        logging: {
+          type: ['boolean', 'string'],
+          description: 'Enable logging (true, false, or "verbose")',
+        },
+      },
+      required: ['serverId', 'routes'],
+    },
+  },
+  {
+    name: 'start_server',
+    description: 'Start a mock server listening on a specified port',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server to start',
+        },
+        port: {
+          type: 'number',
+          description: 'Port number to listen on',
+        },
+      },
+      required: ['serverId', 'port'],
+    },
+  },
+  {
+    name: 'stop_server',
+    description: 'Stop a running mock server',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server to stop',
+        },
+      },
+      required: ['serverId'],
+    },
+  },
+  {
+    name: 'list_servers',
+    description: 'List all mock server instances and their status',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'get_server_info',
+    description: 'Get detailed information about a mock server including routes, presets, and state',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+      },
+      required: ['serverId'],
+    },
+  },
+  {
+    name: 'add_route',
+    description: 'Add a new route to an existing mock server',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        route: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Unique name for the route' },
+            mockRoute: { type: 'string', description: 'URL pattern to match' },
+            method: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] },
+            testScope: { type: 'string' },
+            jsonTemplate: { type: 'string' },
+            latency: { type: ['number', 'string'] },
+          },
+          required: ['name', 'mockRoute', 'method'],
+        },
+      },
+      required: ['serverId', 'route'],
+    },
+  },
+  {
+    name: 'update_route',
+    description: 'Update an existing route configuration',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        routeName: {
+          type: 'string',
+          description: 'Name of the route to update',
+        },
+        updates: {
+          type: 'object',
+          properties: {
+            mockRoute: { type: 'string' },
+            method: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] },
+            testScope: { type: 'string' },
+            testScenario: { type: ['string', 'number'] },
+            jsonTemplate: { type: 'string' },
+            latency: { type: ['number', 'string'] },
+          },
+        },
+      },
+      required: ['serverId', 'routeName', 'updates'],
+    },
+  },
+  {
+    name: 'delete_route',
+    description: 'Delete a route from a mock server',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        routeName: {
+          type: 'string',
+          description: 'Name of the route to delete',
+        },
+      },
+      required: ['serverId', 'routeName'],
+    },
+  },
+  {
+    name: 'set_scenario',
+    description: 'Change a route\'s scenario and/or scope for testing different responses',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        routeName: {
+          type: 'string',
+          description: 'Name of the route to update',
+        },
+        scope: {
+          type: 'string',
+          enum: ['success', 'created', 'noContent', 'badRequest', 'unauthorized', 'forbidden', 'notFound', 'timeout', 'conflict', 'error'],
+          description: 'Response scope (determines HTTP status code)',
+        },
+        scenario: {
+          type: ['string', 'number'],
+          description: 'Scenario index or name to activate',
+        },
+      },
+      required: ['serverId', 'routeName'],
+    },
+  },
+  {
+    name: 'list_presets',
+    description: 'List available presets for a mock server',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+      },
+      required: ['serverId'],
+    },
+  },
+  {
+    name: 'activate_preset',
+    description: 'Activate a preset to switch multiple routes at once',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        presetName: {
+          type: 'string',
+          description: 'Name of the preset to activate (use "default" to reset)',
+        },
+      },
+      required: ['serverId', 'presetName'],
+    },
+  },
+  {
+    name: 'add_preset',
+    description: 'Add a new preset configuration',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        presetName: {
+          type: 'string',
+          description: 'Name for the new preset',
+        },
+        config: {
+          type: 'object',
+          description: 'Preset configuration mapping route patterns to settings',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              scenario: { type: ['string', 'number'] },
+              scope: { type: 'string' },
+              latency: { type: ['number', 'string'] },
+            },
+          },
+        },
+      },
+      required: ['serverId', 'presetName', 'config'],
+    },
+  },
+  {
+    name: 'reset_server',
+    description: 'Reset mock server state to initial configuration',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server to reset',
+        },
+      },
+      required: ['serverId'],
+    },
+  },
+  {
+    name: 'test_route',
+    description: 'Make a test request to a mock server route and return the response',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: {
+          type: 'string',
+          description: 'ID of the mock server',
+        },
+        path: {
+          type: 'string',
+          description: 'URL path to request (e.g., "/api/users")',
+        },
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+          description: 'HTTP method',
+          default: 'GET',
+        },
+        body: {
+          type: 'object',
+          description: 'Request body for POST/PUT/PATCH requests',
+        },
+        queryParams: {
+          type: 'object',
+          description: 'Query parameters to include',
+        },
+      },
+      required: ['serverId', 'path'],
+    },
+  },
+];
+
+// Handle list tools request
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools };
+});
+
+// Handle list resources request
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  const resources = [];
+
+  for (const [serverId, serverData] of servers) {
+    resources.push({
+      uri: `mock-server://${serverId}/config`,
+      name: `${serverId} Configuration`,
+      description: `Configuration for mock server ${serverId}`,
+      mimeType: 'application/json',
+    });
+
+    resources.push({
+      uri: `mock-server://${serverId}/routes`,
+      name: `${serverId} Routes`,
+      description: `Route definitions for mock server ${serverId}`,
+      mimeType: 'application/json',
+    });
+  }
+
+  return { resources };
+});
+
+// Handle read resource request
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const uri = request.params.uri;
+  const match = uri.match(/^mock-server:\/\/([^/]+)\/(.+)$/);
+
+  if (!match) {
+    throw new Error(`Invalid resource URI: ${uri}`);
+  }
+
+  const [, serverId, resourceType] = match;
+  const serverData = servers.get(serverId);
+
+  if (!serverData) {
+    throw new Error(`Server not found: ${serverId}`);
+  }
+
+  let content;
+
+  switch (resourceType) {
+    case 'config':
+      content = {
+        serverId,
+        status: serverData.httpServer ? 'running' : 'stopped',
+        port: serverData.port,
+        activePreset: serverData.mockInstance.activePreset,
+        logging: serverData.mockInstance.logging,
+        routeCount: serverData.mockInstance.routes.length,
+        presetCount: Object.keys(serverData.mockInstance.presets).length,
+      };
+      break;
+
+    case 'routes':
+      content = serverData.mockInstance.routes.map(r => ({
+        name: r.name,
+        mockRoute: r.mockRoute,
+        method: r.method,
+        testScope: r.testScope,
+        testScenario: r.testScenario,
+        latency: r.latency,
+        hasTemplate: !!r.jsonTemplate,
+      }));
+      break;
+
+    default:
+      throw new Error(`Unknown resource type: ${resourceType}`);
+  }
+
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'application/json',
+        text: JSON.stringify(content, null, 2),
+      },
+    ],
+  };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case 'create_mock_server': {
+        const { serverId, routes, presets, jsonStore, logging } = args;
+
+        if (servers.has(serverId)) {
+          throw new Error(`Server with ID "${serverId}" already exists`);
+        }
+
+        // Convert routes to mock-json-api format
+        const mockRoutes = routes.map(r => ({
+          name: r.name,
+          mockRoute: r.mockRoute,
+          method: r.method.toUpperCase(),
+          testScope: r.testScope || 'success',
+          testScenario: r.testScenario || 0,
+          jsonTemplate: r.jsonTemplate || '{}',
+          latency: r.latency,
+        }));
+
+        const config = {
+          mockRoutes,
+          presets: presets || {},
+          jsonStore,
+          logging: logging || false,
+        };
+
+        const mockInstance = mock(config);
+        const app = mockInstance.createServer();
+
+        servers.set(serverId, {
+          mockInstance,
+          app,
+          config,
+          httpServer: null,
+          port: null,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                serverId,
+                message: `Mock server "${serverId}" created with ${routes.length} routes`,
+                routes: mockRoutes.map(r => r.name),
+                presets: Object.keys(presets || {}),
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'start_server': {
+        const { serverId, port } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        if (serverData.httpServer) {
+          throw new Error(`Server "${serverId}" is already running on port ${serverData.port}`);
+        }
+
+        return new Promise((resolve, reject) => {
+          serverData.httpServer = serverData.app.listen(port, () => {
+            serverData.port = port;
+            resolve({
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    success: true,
+                    serverId,
+                    port,
+                    message: `Mock server "${serverId}" started on port ${port}`,
+                    baseUrl: `http://localhost:${port}`,
+                  }, null, 2),
+                },
+              ],
+            });
+          });
+
+          serverData.httpServer.on('error', (err) => {
+            reject(new Error(`Failed to start server: ${err.message}`));
+          });
+        });
+      }
+
+      case 'stop_server': {
+        const { serverId } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        if (!serverData.httpServer) {
+          throw new Error(`Server "${serverId}" is not running`);
+        }
+
+        return new Promise((resolve) => {
+          serverData.httpServer.close(() => {
+            const port = serverData.port;
+            serverData.httpServer = null;
+            serverData.port = null;
+
+            resolve({
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    success: true,
+                    serverId,
+                    message: `Mock server "${serverId}" stopped (was on port ${port})`,
+                  }, null, 2),
+                },
+              ],
+            });
+          });
+        });
+      }
+
+      case 'list_servers': {
+        const serverList = [];
+
+        for (const [serverId, serverData] of servers) {
+          serverList.push({
+            serverId,
+            status: serverData.httpServer ? 'running' : 'stopped',
+            port: serverData.port,
+            routeCount: serverData.mockInstance.routes.length,
+            activePreset: serverData.mockInstance.activePreset,
+          });
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                servers: serverList,
+                total: serverList.length,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_server_info': {
+        const { serverId } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        const info = {
+          serverId,
+          status: serverData.httpServer ? 'running' : 'stopped',
+          port: serverData.port,
+          baseUrl: serverData.port ? `http://localhost:${serverData.port}` : null,
+          activePreset: serverData.mockInstance.activePreset,
+          routes: serverData.mockInstance.routes.map(r => ({
+            name: r.name,
+            mockRoute: r.mockRoute,
+            method: r.method,
+            testScope: r.testScope,
+            testScenario: r.testScenario,
+            latency: r.latency,
+          })),
+          presets: Object.keys(serverData.mockInstance.presets),
+        };
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(info, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'add_route': {
+        const { serverId, route } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        // Check for duplicate name
+        if (serverData.mockInstance.routes.find(r => r.name === route.name)) {
+          throw new Error(`Route with name "${route.name}" already exists`);
+        }
+
+        const newRoute = {
+          name: route.name,
+          mockRoute: route.mockRoute,
+          method: route.method.toUpperCase(),
+          testScope: route.testScope || 'success',
+          testScenario: route.testScenario || 0,
+          jsonTemplate: route.jsonTemplate || '{}',
+          latency: route.latency,
+        };
+
+        serverData.mockInstance.routes.push(newRoute);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Route "${route.name}" added to server "${serverId}"`,
+                route: newRoute,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_route': {
+        const { serverId, routeName, updates } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        const route = serverData.mockInstance.routes.find(r => r.name === routeName);
+
+        if (!route) {
+          throw new Error(`Route "${routeName}" not found`);
+        }
+
+        // Apply updates
+        if (updates.mockRoute !== undefined) route.mockRoute = updates.mockRoute;
+        if (updates.method !== undefined) route.method = updates.method.toUpperCase();
+        if (updates.testScope !== undefined) route.testScope = updates.testScope;
+        if (updates.testScenario !== undefined) route.testScenario = updates.testScenario;
+        if (updates.jsonTemplate !== undefined) route.jsonTemplate = updates.jsonTemplate;
+        if (updates.latency !== undefined) route.latency = updates.latency;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Route "${routeName}" updated`,
+                route: {
+                  name: route.name,
+                  mockRoute: route.mockRoute,
+                  method: route.method,
+                  testScope: route.testScope,
+                  testScenario: route.testScenario,
+                  latency: route.latency,
+                },
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'delete_route': {
+        const { serverId, routeName } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        const index = serverData.mockInstance.routes.findIndex(r => r.name === routeName);
+
+        if (index === -1) {
+          throw new Error(`Route "${routeName}" not found`);
+        }
+
+        serverData.mockInstance.routes.splice(index, 1);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Route "${routeName}" deleted from server "${serverId}"`,
+                remainingRoutes: serverData.mockInstance.routes.map(r => r.name),
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'set_scenario': {
+        const { serverId, routeName, scope, scenario } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        const route = serverData.mockInstance.routes.find(r => r.name === routeName);
+
+        if (!route) {
+          throw new Error(`Route "${routeName}" not found`);
+        }
+
+        if (scope !== undefined) route.testScope = scope;
+        if (scenario !== undefined) route.testScenario = scenario;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Scenario updated for route "${routeName}"`,
+                route: {
+                  name: route.name,
+                  testScope: route.testScope,
+                  testScenario: route.testScenario,
+                },
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_presets': {
+        const { serverId } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                activePreset: serverData.mockInstance.activePreset,
+                presets: Object.keys(serverData.mockInstance.presets),
+                presetDetails: serverData.mockInstance.presets,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'activate_preset': {
+        const { serverId, presetName } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        if (presetName === 'default') {
+          serverData.mockInstance.reset();
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  success: true,
+                  message: 'Reset to default configuration',
+                  activePreset: null,
+                }, null, 2),
+              },
+            ],
+          };
+        }
+
+        if (!serverData.mockInstance.presets.hasOwnProperty(presetName)) {
+          throw new Error(`Preset "${presetName}" not found. Available: ${Object.keys(serverData.mockInstance.presets).join(', ')}`);
+        }
+
+        // Simulate preset activation by directly manipulating routes
+        const preset = serverData.mockInstance.presets[presetName];
+        let routesUpdated = 0;
+
+        // Reset first
+        serverData.mockInstance.reset();
+
+        // Apply preset
+        for (const [pattern, config] of Object.entries(preset)) {
+          const matchingRoutes = serverData.mockInstance._matchRoutesByPattern(pattern);
+
+          for (const route of matchingRoutes) {
+            if (config.scenario !== undefined) route.testScenario = config.scenario;
+            if (config.scope !== undefined) route.testScope = config.scope;
+            if (config.latency !== undefined) route.latency = config.latency;
+            routesUpdated++;
+          }
+        }
+
+        serverData.mockInstance.activePreset = presetName;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                preset: presetName,
+                message: `Preset "${presetName}" activated`,
+                routesUpdated,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'add_preset': {
+        const { serverId, presetName, config } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        serverData.mockInstance.presets[presetName] = config;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Preset "${presetName}" added`,
+                preset: config,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'reset_server': {
+        const { serverId } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        serverData.mockInstance.reset();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                serverId,
+                message: 'Server state reset to initial configuration',
+                activePreset: null,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'test_route': {
+        const { serverId, path, method = 'GET', body, queryParams } = args;
+        const serverData = servers.get(serverId);
+
+        if (!serverData) {
+          throw new Error(`Server "${serverId}" not found`);
+        }
+
+        if (!serverData.httpServer) {
+          throw new Error(`Server "${serverId}" is not running. Start it first with start_server.`);
+        }
+
+        // Build URL with query params
+        let url = `http://localhost:${serverData.port}${path}`;
+        if (queryParams) {
+          const params = new URLSearchParams(queryParams);
+          url += `?${params.toString()}`;
+        }
+
+        // Make the request
+        const fetchOptions = {
+          method: method.toUpperCase(),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        };
+
+        if (body && ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase())) {
+          fetchOptions.body = JSON.stringify(body);
+        }
+
+        const response = await fetch(url, fetchOptions);
+        let responseBody;
+
+        try {
+          responseBody = await response.json();
+        } catch {
+          responseBody = await response.text();
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                request: {
+                  method: method.toUpperCase(),
+                  url,
+                  body,
+                },
+                response: {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: Object.fromEntries(response.headers.entries()),
+                  body: responseBody,
+                },
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: true,
+            message: error.message,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start the server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('mock-json-api MCP server running on stdio');
+}
+
+main().catch(console.error);

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -15,7 +15,25 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import mock from 'mock-json-api';
+import { match } from 'path-to-regexp';
+import { createRequire } from 'module';
+
+// Import mock-json-api (CommonJS module)
+const require = createRequire(import.meta.url);
+const mock = require('mock-json-api');
+const { version } = require('./package.json');
+
+// Constants
+const TEST_SCOPES = Object.freeze([
+  'success', 'created', 'noContent', 'badRequest',
+  'unauthorized', 'forbidden', 'notFound', 'timeout', 'conflict', 'error'
+]);
+
+const HTTP_METHODS = Object.freeze(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+const MAX_ROUTES_PER_SERVER = 1000;
+const MAX_SERVERS = 100;
+const SERVER_SHUTDOWN_TIMEOUT = 30000;
 
 // Store for active mock server instances
 const servers = new Map();
@@ -24,7 +42,7 @@ const servers = new Map();
 const server = new Server(
   {
     name: 'mock-json-api-mcp-server',
-    version: '1.0.0',
+    version,
   },
   {
     capabilities: {
@@ -34,7 +52,69 @@ const server = new Server(
   }
 );
 
-// Define available tools
+/**
+ * Compile route matcher for parameterized routes
+ * @param {object} route - Route configuration
+ */
+function compileRouteMatcher(route) {
+  if (route.mockRoute && !route.mockRoute.includes('(') && route.mockRoute.includes(':')) {
+    try {
+      route._matcher = match(route.mockRoute, { decode: decodeURIComponent });
+      route._isParamRoute = true;
+    } catch (e) {
+      route._isParamRoute = false;
+    }
+  } else {
+    route._isParamRoute = false;
+  }
+}
+
+/**
+ * Create a standardized success response
+ */
+function successResponse(data) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+/**
+ * Create a standardized error response
+ */
+function errorResponse(message) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: true, message }, null, 2) }],
+    isError: true,
+  };
+}
+
+/**
+ * Validate server exists
+ */
+function getServer(serverId) {
+  const serverData = servers.get(serverId);
+  if (!serverData) {
+    throw new Error(`Server "${serverId}" not found`);
+  }
+  return serverData;
+}
+
+/**
+ * Validate server ID format
+ */
+function validateServerId(serverId) {
+  if (!serverId || typeof serverId !== 'string') {
+    throw new Error('Server ID must be a non-empty string');
+  }
+  if (serverId.length > 100) {
+    throw new Error('Server ID must be 100 characters or less');
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(serverId)) {
+    throw new Error('Server ID must contain only alphanumeric characters, hyphens, and underscores');
+  }
+}
+
+// Tool definitions
 const tools = [
   {
     name: 'create_mock_server',
@@ -44,7 +124,7 @@ const tools = [
       properties: {
         serverId: {
           type: 'string',
-          description: 'Unique identifier for this mock server instance',
+          description: 'Unique identifier for this mock server instance (alphanumeric, hyphens, underscores only)',
         },
         routes: {
           type: 'array',
@@ -52,32 +132,12 @@ const tools = [
           items: {
             type: 'object',
             properties: {
-              name: {
-                type: 'string',
-                description: 'Unique name for the route',
-              },
-              mockRoute: {
-                type: 'string',
-                description: 'URL pattern to match (e.g., "/api/users" or "/api/users/:id")',
-              },
-              method: {
-                type: 'string',
-                enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-                description: 'HTTP method',
-              },
-              testScope: {
-                type: 'string',
-                enum: ['success', 'created', 'noContent', 'badRequest', 'unauthorized', 'forbidden', 'notFound', 'timeout', 'conflict', 'error'],
-                description: 'Response scope determining HTTP status code',
-              },
-              jsonTemplate: {
-                type: 'string',
-                description: 'JSON response template (supports dummy-json syntax for data generation)',
-              },
-              latency: {
-                type: ['number', 'string'],
-                description: 'Response delay in ms (number) or range (e.g., "100-500")',
-              },
+              name: { type: 'string', description: 'Unique name for the route' },
+              mockRoute: { type: 'string', description: 'URL pattern to match (e.g., "/api/users" or "/api/users/:id")' },
+              method: { type: 'string', enum: HTTP_METHODS, description: 'HTTP method' },
+              testScope: { type: 'string', enum: TEST_SCOPES, description: 'Response scope determining HTTP status code' },
+              jsonTemplate: { type: 'string', description: 'JSON response template (supports dummy-json syntax)' },
+              latency: { type: ['number', 'string'], description: 'Response delay in ms or range (e.g., "100-500")' },
             },
             required: ['name', 'mockRoute', 'method'],
           },
@@ -85,21 +145,6 @@ const tools = [
         presets: {
           type: 'object',
           description: 'Named presets for switching multiple routes at once',
-          additionalProperties: {
-            type: 'object',
-            additionalProperties: {
-              type: 'object',
-              properties: {
-                scenario: { type: ['string', 'number'] },
-                scope: { type: 'string' },
-                latency: { type: ['number', 'string'] },
-              },
-            },
-          },
-        },
-        jsonStore: {
-          type: 'string',
-          description: 'Path to JSON file for persisting mock data',
         },
         logging: {
           type: ['boolean', 'string'],
@@ -115,14 +160,8 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server to start',
-        },
-        port: {
-          type: 'number',
-          description: 'Port number to listen on',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server to start' },
+        port: { type: 'number', description: 'Port number to listen on (1024-65535)' },
       },
       required: ['serverId', 'port'],
     },
@@ -133,10 +172,18 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server to stop',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server to stop' },
+      },
+      required: ['serverId'],
+    },
+  },
+  {
+    name: 'destroy_server',
+    description: 'Stop and completely remove a mock server instance',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serverId: { type: 'string', description: 'ID of the mock server to destroy' },
       },
       required: ['serverId'],
     },
@@ -144,10 +191,7 @@ const tools = [
   {
     name: 'list_servers',
     description: 'List all mock server instances and their status',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-    },
+    inputSchema: { type: 'object', properties: {} },
   },
   {
     name: 'get_server_info',
@@ -155,10 +199,7 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
       },
       required: ['serverId'],
     },
@@ -169,17 +210,14 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
         route: {
           type: 'object',
           properties: {
             name: { type: 'string', description: 'Unique name for the route' },
             mockRoute: { type: 'string', description: 'URL pattern to match' },
-            method: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] },
-            testScope: { type: 'string' },
+            method: { type: 'string', enum: HTTP_METHODS },
+            testScope: { type: 'string', enum: TEST_SCOPES },
             jsonTemplate: { type: 'string' },
             latency: { type: ['number', 'string'] },
           },
@@ -195,20 +233,14 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        routeName: {
-          type: 'string',
-          description: 'Name of the route to update',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        routeName: { type: 'string', description: 'Name of the route to update' },
         updates: {
           type: 'object',
           properties: {
             mockRoute: { type: 'string' },
-            method: { type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] },
-            testScope: { type: 'string' },
+            method: { type: 'string', enum: HTTP_METHODS },
+            testScope: { type: 'string', enum: TEST_SCOPES },
             testScenario: { type: ['string', 'number'] },
             jsonTemplate: { type: 'string' },
             latency: { type: ['number', 'string'] },
@@ -224,41 +256,22 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        routeName: {
-          type: 'string',
-          description: 'Name of the route to delete',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        routeName: { type: 'string', description: 'Name of the route to delete' },
       },
       required: ['serverId', 'routeName'],
     },
   },
   {
     name: 'set_scenario',
-    description: 'Change a route\'s scenario and/or scope for testing different responses',
+    description: "Change a route's scenario and/or scope for testing different responses",
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        routeName: {
-          type: 'string',
-          description: 'Name of the route to update',
-        },
-        scope: {
-          type: 'string',
-          enum: ['success', 'created', 'noContent', 'badRequest', 'unauthorized', 'forbidden', 'notFound', 'timeout', 'conflict', 'error'],
-          description: 'Response scope (determines HTTP status code)',
-        },
-        scenario: {
-          type: ['string', 'number'],
-          description: 'Scenario index or name to activate',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        routeName: { type: 'string', description: 'Name of the route to update' },
+        scope: { type: 'string', enum: TEST_SCOPES, description: 'Response scope (determines HTTP status code)' },
+        scenario: { type: ['string', 'number'], description: 'Scenario index or name to activate' },
       },
       required: ['serverId', 'routeName'],
     },
@@ -269,10 +282,7 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
       },
       required: ['serverId'],
     },
@@ -283,14 +293,8 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        presetName: {
-          type: 'string',
-          description: 'Name of the preset to activate (use "default" to reset)',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        presetName: { type: 'string', description: 'Name of the preset to activate (use "default" to reset)' },
       },
       required: ['serverId', 'presetName'],
     },
@@ -301,25 +305,11 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        presetName: {
-          type: 'string',
-          description: 'Name for the new preset',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        presetName: { type: 'string', description: 'Name for the new preset' },
         config: {
           type: 'object',
           description: 'Preset configuration mapping route patterns to settings',
-          additionalProperties: {
-            type: 'object',
-            properties: {
-              scenario: { type: ['string', 'number'] },
-              scope: { type: 'string' },
-              latency: { type: ['number', 'string'] },
-            },
-          },
         },
       },
       required: ['serverId', 'presetName', 'config'],
@@ -331,10 +321,7 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server to reset',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server to reset' },
       },
       required: ['serverId'],
     },
@@ -345,33 +332,490 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        serverId: {
-          type: 'string',
-          description: 'ID of the mock server',
-        },
-        path: {
-          type: 'string',
-          description: 'URL path to request (e.g., "/api/users")',
-        },
-        method: {
-          type: 'string',
-          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-          description: 'HTTP method',
-          default: 'GET',
-        },
-        body: {
-          type: 'object',
-          description: 'Request body for POST/PUT/PATCH requests',
-        },
-        queryParams: {
-          type: 'object',
-          description: 'Query parameters to include',
-        },
+        serverId: { type: 'string', description: 'ID of the mock server' },
+        path: { type: 'string', description: 'URL path to request (e.g., "/api/users")' },
+        method: { type: 'string', enum: HTTP_METHODS, description: 'HTTP method', default: 'GET' },
+        body: { type: 'object', description: 'Request body for POST/PUT/PATCH requests' },
+        queryParams: { type: 'object', description: 'Query parameters to include' },
       },
       required: ['serverId', 'path'],
     },
   },
 ];
+
+// Tool handlers
+const toolHandlers = {
+  async create_mock_server({ serverId, routes, presets, logging }) {
+    validateServerId(serverId);
+
+    if (servers.has(serverId)) {
+      throw new Error(`Server with ID "${serverId}" already exists`);
+    }
+
+    if (servers.size >= MAX_SERVERS) {
+      throw new Error(`Maximum number of servers (${MAX_SERVERS}) reached`);
+    }
+
+    if (!routes || routes.length === 0) {
+      throw new Error('At least one route is required');
+    }
+
+    if (routes.length > MAX_ROUTES_PER_SERVER) {
+      throw new Error(`Maximum ${MAX_ROUTES_PER_SERVER} routes per server`);
+    }
+
+    // Convert routes to mock-json-api format and compile matchers
+    const mockRoutes = routes.map(r => {
+      const route = {
+        name: r.name,
+        mockRoute: r.mockRoute,
+        method: r.method.toUpperCase(),
+        testScope: r.testScope || 'success',
+        testScenario: r.testScenario || 0,
+        jsonTemplate: r.jsonTemplate || '{}',
+        latency: r.latency,
+      };
+      compileRouteMatcher(route);
+      return route;
+    });
+
+    const config = {
+      mockRoutes,
+      presets: presets || {},
+      logging: logging || false,
+    };
+
+    const mockInstance = mock(config);
+    const app = mockInstance.createServer();
+
+    servers.set(serverId, {
+      mockInstance,
+      app,
+      config,
+      httpServer: null,
+      port: null,
+    });
+
+    return successResponse({
+      success: true,
+      serverId,
+      message: `Mock server "${serverId}" created with ${routes.length} route(s)`,
+      routes: mockRoutes.map(r => r.name),
+      presets: Object.keys(presets || {}),
+    });
+  },
+
+  async start_server({ serverId, port }) {
+    const serverData = getServer(serverId);
+
+    if (serverData.httpServer) {
+      throw new Error(`Server "${serverId}" is already running on port ${serverData.port}`);
+    }
+
+    if (port < 1024 || port > 65535) {
+      throw new Error('Port must be between 1024 and 65535');
+    }
+
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+
+      const httpServer = serverData.app.listen(port, () => {
+        if (resolved) return;
+        resolved = true;
+        serverData.httpServer = httpServer;
+        serverData.port = port;
+        resolve(successResponse({
+          success: true,
+          serverId,
+          port,
+          message: `Mock server "${serverId}" started on port ${port}`,
+          baseUrl: `http://localhost:${port}`,
+        }));
+      });
+
+      httpServer.on('error', (err) => {
+        if (resolved) return;
+        resolved = true;
+        reject(new Error(`Failed to start server: ${err.message}`));
+      });
+    });
+  },
+
+  async stop_server({ serverId }) {
+    const serverData = getServer(serverId);
+
+    if (!serverData.httpServer) {
+      throw new Error(`Server "${serverId}" is not running`);
+    }
+
+    return new Promise((resolve, reject) => {
+      const port = serverData.port;
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (resolved) return;
+        resolved = true;
+        // Force close
+        serverData.httpServer.closeAllConnections?.();
+        serverData.httpServer = null;
+        serverData.port = null;
+        resolve(successResponse({
+          success: true,
+          serverId,
+          message: `Mock server "${serverId}" force-stopped after timeout (was on port ${port})`,
+          warning: 'Server was force-stopped due to timeout',
+        }));
+      }, SERVER_SHUTDOWN_TIMEOUT);
+
+      serverData.httpServer.close((err) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+
+        if (err) {
+          reject(new Error(`Failed to stop server: ${err.message}`));
+          return;
+        }
+
+        serverData.httpServer = null;
+        serverData.port = null;
+
+        resolve(successResponse({
+          success: true,
+          serverId,
+          message: `Mock server "${serverId}" stopped (was on port ${port})`,
+        }));
+      });
+    });
+  },
+
+  async destroy_server({ serverId }) {
+    const serverData = getServer(serverId);
+
+    // Stop if running
+    if (serverData.httpServer) {
+      await toolHandlers.stop_server({ serverId });
+    }
+
+    servers.delete(serverId);
+
+    return successResponse({
+      success: true,
+      serverId,
+      message: `Mock server "${serverId}" destroyed`,
+    });
+  },
+
+  async list_servers() {
+    const serverList = [];
+
+    for (const [serverId, serverData] of servers) {
+      serverList.push({
+        serverId,
+        status: serverData.httpServer ? 'running' : 'stopped',
+        port: serverData.port,
+        baseUrl: serverData.port ? `http://localhost:${serverData.port}` : null,
+        routeCount: serverData.mockInstance.routes.length,
+        activePreset: serverData.mockInstance.activePreset,
+      });
+    }
+
+    return successResponse({
+      servers: serverList,
+      total: serverList.length,
+    });
+  },
+
+  async get_server_info({ serverId }) {
+    const serverData = getServer(serverId);
+
+    return successResponse({
+      serverId,
+      status: serverData.httpServer ? 'running' : 'stopped',
+      port: serverData.port,
+      baseUrl: serverData.port ? `http://localhost:${serverData.port}` : null,
+      activePreset: serverData.mockInstance.activePreset,
+      routes: serverData.mockInstance.routes.map(r => ({
+        name: r.name,
+        mockRoute: r.mockRoute,
+        method: r.method,
+        testScope: r.testScope,
+        testScenario: r.testScenario,
+        latency: r.latency,
+      })),
+      presets: Object.keys(serverData.mockInstance.presets),
+    });
+  },
+
+  async add_route({ serverId, route }) {
+    const serverData = getServer(serverId);
+
+    if (serverData.mockInstance.routes.length >= MAX_ROUTES_PER_SERVER) {
+      throw new Error(`Maximum ${MAX_ROUTES_PER_SERVER} routes per server`);
+    }
+
+    if (serverData.mockInstance.routes.find(r => r.name === route.name)) {
+      throw new Error(`Route with name "${route.name}" already exists`);
+    }
+
+    const newRoute = {
+      name: route.name,
+      mockRoute: route.mockRoute,
+      method: route.method.toUpperCase(),
+      testScope: route.testScope || 'success',
+      testScenario: route.testScenario || 0,
+      jsonTemplate: route.jsonTemplate || '{}',
+      latency: route.latency,
+    };
+
+    // Compile matcher for parameterized routes
+    compileRouteMatcher(newRoute);
+
+    serverData.mockInstance.routes.push(newRoute);
+
+    return successResponse({
+      success: true,
+      message: `Route "${route.name}" added to server "${serverId}"`,
+      route: {
+        name: newRoute.name,
+        mockRoute: newRoute.mockRoute,
+        method: newRoute.method,
+        testScope: newRoute.testScope,
+      },
+    });
+  },
+
+  async update_route({ serverId, routeName, updates }) {
+    const serverData = getServer(serverId);
+    const route = serverData.mockInstance.routes.find(r => r.name === routeName);
+
+    if (!route) {
+      throw new Error(`Route "${routeName}" not found`);
+    }
+
+    // Track if mockRoute changed (needs recompilation)
+    const mockRouteChanged = updates.mockRoute !== undefined && updates.mockRoute !== route.mockRoute;
+
+    // Apply updates
+    if (updates.mockRoute !== undefined) route.mockRoute = updates.mockRoute;
+    if (updates.method !== undefined) route.method = updates.method.toUpperCase();
+    if (updates.testScope !== undefined) route.testScope = updates.testScope;
+    if (updates.testScenario !== undefined) route.testScenario = updates.testScenario;
+    if (updates.jsonTemplate !== undefined) route.jsonTemplate = updates.jsonTemplate;
+    if (updates.latency !== undefined) route.latency = updates.latency;
+
+    // Recompile matcher if mockRoute changed
+    if (mockRouteChanged) {
+      compileRouteMatcher(route);
+    }
+
+    return successResponse({
+      success: true,
+      message: `Route "${routeName}" updated`,
+      route: {
+        name: route.name,
+        mockRoute: route.mockRoute,
+        method: route.method,
+        testScope: route.testScope,
+        testScenario: route.testScenario,
+        latency: route.latency,
+      },
+    });
+  },
+
+  async delete_route({ serverId, routeName }) {
+    const serverData = getServer(serverId);
+    const index = serverData.mockInstance.routes.findIndex(r => r.name === routeName);
+
+    if (index === -1) {
+      throw new Error(`Route "${routeName}" not found`);
+    }
+
+    serverData.mockInstance.routes.splice(index, 1);
+
+    return successResponse({
+      success: true,
+      message: `Route "${routeName}" deleted from server "${serverId}"`,
+      remainingRoutes: serverData.mockInstance.routes.map(r => r.name),
+    });
+  },
+
+  async set_scenario({ serverId, routeName, scope, scenario }) {
+    const serverData = getServer(serverId);
+    const route = serverData.mockInstance.routes.find(r => r.name === routeName);
+
+    if (!route) {
+      throw new Error(`Route "${routeName}" not found`);
+    }
+
+    if (scope !== undefined) {
+      if (!TEST_SCOPES.includes(scope)) {
+        throw new Error(`Invalid scope "${scope}". Must be one of: ${TEST_SCOPES.join(', ')}`);
+      }
+      route.testScope = scope;
+    }
+    if (scenario !== undefined) route.testScenario = scenario;
+
+    return successResponse({
+      success: true,
+      message: `Scenario updated for route "${routeName}"`,
+      route: {
+        name: route.name,
+        testScope: route.testScope,
+        testScenario: route.testScenario,
+      },
+    });
+  },
+
+  async list_presets({ serverId }) {
+    const serverData = getServer(serverId);
+
+    return successResponse({
+      activePreset: serverData.mockInstance.activePreset,
+      presets: Object.keys(serverData.mockInstance.presets),
+      presetDetails: serverData.mockInstance.presets,
+    });
+  },
+
+  async activate_preset({ serverId, presetName }) {
+    const serverData = getServer(serverId);
+
+    if (presetName === 'default') {
+      serverData.mockInstance.reset();
+      return successResponse({
+        success: true,
+        message: 'Reset to default configuration',
+        activePreset: null,
+      });
+    }
+
+    if (!Object.hasOwn(serverData.mockInstance.presets, presetName)) {
+      throw new Error(`Preset "${presetName}" not found. Available: ${Object.keys(serverData.mockInstance.presets).join(', ') || 'none'}`);
+    }
+
+    // Reset first
+    serverData.mockInstance.reset();
+
+    // Apply preset
+    const preset = serverData.mockInstance.presets[presetName];
+    let routesUpdated = 0;
+
+    for (const [pattern, config] of Object.entries(preset)) {
+      // Match routes by pattern
+      let matchingRoutes;
+      if (pattern === '*') {
+        matchingRoutes = serverData.mockInstance.routes;
+      } else if (pattern.endsWith('*')) {
+        const prefix = pattern.slice(0, -1);
+        matchingRoutes = serverData.mockInstance.routes.filter(r => r.name?.startsWith(prefix));
+      } else {
+        const route = serverData.mockInstance.routes.find(r => r.name === pattern);
+        matchingRoutes = route ? [route] : [];
+      }
+
+      for (const route of matchingRoutes) {
+        if (config.scenario !== undefined) route.testScenario = config.scenario;
+        if (config.scope !== undefined) route.testScope = config.scope;
+        if (config.latency !== undefined) route.latency = config.latency;
+        routesUpdated++;
+      }
+    }
+
+    serverData.mockInstance.activePreset = presetName;
+
+    return successResponse({
+      success: true,
+      preset: presetName,
+      message: `Preset "${presetName}" activated`,
+      routesUpdated,
+    });
+  },
+
+  async add_preset({ serverId, presetName, config }) {
+    const serverData = getServer(serverId);
+
+    if (!presetName || typeof presetName !== 'string') {
+      throw new Error('Preset name must be a non-empty string');
+    }
+
+    serverData.mockInstance.presets[presetName] = config;
+
+    return successResponse({
+      success: true,
+      message: `Preset "${presetName}" added`,
+      preset: config,
+    });
+  },
+
+  async reset_server({ serverId }) {
+    const serverData = getServer(serverId);
+
+    serverData.mockInstance.reset();
+
+    return successResponse({
+      success: true,
+      serverId,
+      message: 'Server state reset to initial configuration',
+      activePreset: null,
+    });
+  },
+
+  async test_route({ serverId, path, method = 'GET', body, queryParams }) {
+    const serverData = getServer(serverId);
+
+    if (!serverData.httpServer) {
+      throw new Error(`Server "${serverId}" is not running. Start it first with start_server.`);
+    }
+
+    // Build URL with query params
+    let url = `http://localhost:${serverData.port}${path}`;
+    if (queryParams && Object.keys(queryParams).length > 0) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(queryParams)) {
+        params.append(key, String(value));
+      }
+      url += `?${params.toString()}`;
+    }
+
+    // Make the request
+    const fetchOptions = {
+      method: method.toUpperCase(),
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    if (body && ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase())) {
+      fetchOptions.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, fetchOptions);
+
+    let responseBody;
+    const contentType = response.headers.get('content-type') || '';
+
+    if (contentType.includes('application/json')) {
+      try {
+        responseBody = await response.json();
+      } catch {
+        responseBody = null;
+      }
+    } else {
+      responseBody = await response.text();
+    }
+
+    return successResponse({
+      request: {
+        method: method.toUpperCase(),
+        url,
+        body: body || null,
+      },
+      response: {
+        status: response.status,
+        statusText: response.statusText,
+        body: responseBody,
+      },
+    });
+  },
+};
 
 // Handle list tools request
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -463,554 +907,40 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
+  const handler = toolHandlers[name];
+  if (!handler) {
+    return errorResponse(`Unknown tool: ${name}`);
+  }
+
   try {
-    switch (name) {
-      case 'create_mock_server': {
-        const { serverId, routes, presets, jsonStore, logging } = args;
-
-        if (servers.has(serverId)) {
-          throw new Error(`Server with ID "${serverId}" already exists`);
-        }
-
-        // Convert routes to mock-json-api format
-        const mockRoutes = routes.map(r => ({
-          name: r.name,
-          mockRoute: r.mockRoute,
-          method: r.method.toUpperCase(),
-          testScope: r.testScope || 'success',
-          testScenario: r.testScenario || 0,
-          jsonTemplate: r.jsonTemplate || '{}',
-          latency: r.latency,
-        }));
-
-        const config = {
-          mockRoutes,
-          presets: presets || {},
-          jsonStore,
-          logging: logging || false,
-        };
-
-        const mockInstance = mock(config);
-        const app = mockInstance.createServer();
-
-        servers.set(serverId, {
-          mockInstance,
-          app,
-          config,
-          httpServer: null,
-          port: null,
-        });
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                serverId,
-                message: `Mock server "${serverId}" created with ${routes.length} routes`,
-                routes: mockRoutes.map(r => r.name),
-                presets: Object.keys(presets || {}),
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'start_server': {
-        const { serverId, port } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        if (serverData.httpServer) {
-          throw new Error(`Server "${serverId}" is already running on port ${serverData.port}`);
-        }
-
-        return new Promise((resolve, reject) => {
-          serverData.httpServer = serverData.app.listen(port, () => {
-            serverData.port = port;
-            resolve({
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify({
-                    success: true,
-                    serverId,
-                    port,
-                    message: `Mock server "${serverId}" started on port ${port}`,
-                    baseUrl: `http://localhost:${port}`,
-                  }, null, 2),
-                },
-              ],
-            });
-          });
-
-          serverData.httpServer.on('error', (err) => {
-            reject(new Error(`Failed to start server: ${err.message}`));
-          });
-        });
-      }
-
-      case 'stop_server': {
-        const { serverId } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        if (!serverData.httpServer) {
-          throw new Error(`Server "${serverId}" is not running`);
-        }
-
-        return new Promise((resolve) => {
-          serverData.httpServer.close(() => {
-            const port = serverData.port;
-            serverData.httpServer = null;
-            serverData.port = null;
-
-            resolve({
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify({
-                    success: true,
-                    serverId,
-                    message: `Mock server "${serverId}" stopped (was on port ${port})`,
-                  }, null, 2),
-                },
-              ],
-            });
-          });
-        });
-      }
-
-      case 'list_servers': {
-        const serverList = [];
-
-        for (const [serverId, serverData] of servers) {
-          serverList.push({
-            serverId,
-            status: serverData.httpServer ? 'running' : 'stopped',
-            port: serverData.port,
-            routeCount: serverData.mockInstance.routes.length,
-            activePreset: serverData.mockInstance.activePreset,
-          });
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                servers: serverList,
-                total: serverList.length,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'get_server_info': {
-        const { serverId } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        const info = {
-          serverId,
-          status: serverData.httpServer ? 'running' : 'stopped',
-          port: serverData.port,
-          baseUrl: serverData.port ? `http://localhost:${serverData.port}` : null,
-          activePreset: serverData.mockInstance.activePreset,
-          routes: serverData.mockInstance.routes.map(r => ({
-            name: r.name,
-            mockRoute: r.mockRoute,
-            method: r.method,
-            testScope: r.testScope,
-            testScenario: r.testScenario,
-            latency: r.latency,
-          })),
-          presets: Object.keys(serverData.mockInstance.presets),
-        };
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(info, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'add_route': {
-        const { serverId, route } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        // Check for duplicate name
-        if (serverData.mockInstance.routes.find(r => r.name === route.name)) {
-          throw new Error(`Route with name "${route.name}" already exists`);
-        }
-
-        const newRoute = {
-          name: route.name,
-          mockRoute: route.mockRoute,
-          method: route.method.toUpperCase(),
-          testScope: route.testScope || 'success',
-          testScenario: route.testScenario || 0,
-          jsonTemplate: route.jsonTemplate || '{}',
-          latency: route.latency,
-        };
-
-        serverData.mockInstance.routes.push(newRoute);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: `Route "${route.name}" added to server "${serverId}"`,
-                route: newRoute,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'update_route': {
-        const { serverId, routeName, updates } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        const route = serverData.mockInstance.routes.find(r => r.name === routeName);
-
-        if (!route) {
-          throw new Error(`Route "${routeName}" not found`);
-        }
-
-        // Apply updates
-        if (updates.mockRoute !== undefined) route.mockRoute = updates.mockRoute;
-        if (updates.method !== undefined) route.method = updates.method.toUpperCase();
-        if (updates.testScope !== undefined) route.testScope = updates.testScope;
-        if (updates.testScenario !== undefined) route.testScenario = updates.testScenario;
-        if (updates.jsonTemplate !== undefined) route.jsonTemplate = updates.jsonTemplate;
-        if (updates.latency !== undefined) route.latency = updates.latency;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: `Route "${routeName}" updated`,
-                route: {
-                  name: route.name,
-                  mockRoute: route.mockRoute,
-                  method: route.method,
-                  testScope: route.testScope,
-                  testScenario: route.testScenario,
-                  latency: route.latency,
-                },
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'delete_route': {
-        const { serverId, routeName } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        const index = serverData.mockInstance.routes.findIndex(r => r.name === routeName);
-
-        if (index === -1) {
-          throw new Error(`Route "${routeName}" not found`);
-        }
-
-        serverData.mockInstance.routes.splice(index, 1);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: `Route "${routeName}" deleted from server "${serverId}"`,
-                remainingRoutes: serverData.mockInstance.routes.map(r => r.name),
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'set_scenario': {
-        const { serverId, routeName, scope, scenario } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        const route = serverData.mockInstance.routes.find(r => r.name === routeName);
-
-        if (!route) {
-          throw new Error(`Route "${routeName}" not found`);
-        }
-
-        if (scope !== undefined) route.testScope = scope;
-        if (scenario !== undefined) route.testScenario = scenario;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: `Scenario updated for route "${routeName}"`,
-                route: {
-                  name: route.name,
-                  testScope: route.testScope,
-                  testScenario: route.testScenario,
-                },
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'list_presets': {
-        const { serverId } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                activePreset: serverData.mockInstance.activePreset,
-                presets: Object.keys(serverData.mockInstance.presets),
-                presetDetails: serverData.mockInstance.presets,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'activate_preset': {
-        const { serverId, presetName } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        if (presetName === 'default') {
-          serverData.mockInstance.reset();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  success: true,
-                  message: 'Reset to default configuration',
-                  activePreset: null,
-                }, null, 2),
-              },
-            ],
-          };
-        }
-
-        if (!serverData.mockInstance.presets.hasOwnProperty(presetName)) {
-          throw new Error(`Preset "${presetName}" not found. Available: ${Object.keys(serverData.mockInstance.presets).join(', ')}`);
-        }
-
-        // Simulate preset activation by directly manipulating routes
-        const preset = serverData.mockInstance.presets[presetName];
-        let routesUpdated = 0;
-
-        // Reset first
-        serverData.mockInstance.reset();
-
-        // Apply preset
-        for (const [pattern, config] of Object.entries(preset)) {
-          const matchingRoutes = serverData.mockInstance._matchRoutesByPattern(pattern);
-
-          for (const route of matchingRoutes) {
-            if (config.scenario !== undefined) route.testScenario = config.scenario;
-            if (config.scope !== undefined) route.testScope = config.scope;
-            if (config.latency !== undefined) route.latency = config.latency;
-            routesUpdated++;
-          }
-        }
-
-        serverData.mockInstance.activePreset = presetName;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                preset: presetName,
-                message: `Preset "${presetName}" activated`,
-                routesUpdated,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'add_preset': {
-        const { serverId, presetName, config } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        serverData.mockInstance.presets[presetName] = config;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: `Preset "${presetName}" added`,
-                preset: config,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'reset_server': {
-        const { serverId } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        serverData.mockInstance.reset();
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                serverId,
-                message: 'Server state reset to initial configuration',
-                activePreset: null,
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'test_route': {
-        const { serverId, path, method = 'GET', body, queryParams } = args;
-        const serverData = servers.get(serverId);
-
-        if (!serverData) {
-          throw new Error(`Server "${serverId}" not found`);
-        }
-
-        if (!serverData.httpServer) {
-          throw new Error(`Server "${serverId}" is not running. Start it first with start_server.`);
-        }
-
-        // Build URL with query params
-        let url = `http://localhost:${serverData.port}${path}`;
-        if (queryParams) {
-          const params = new URLSearchParams(queryParams);
-          url += `?${params.toString()}`;
-        }
-
-        // Make the request
-        const fetchOptions = {
-          method: method.toUpperCase(),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        };
-
-        if (body && ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase())) {
-          fetchOptions.body = JSON.stringify(body);
-        }
-
-        const response = await fetch(url, fetchOptions);
-        let responseBody;
-
-        try {
-          responseBody = await response.json();
-        } catch {
-          responseBody = await response.text();
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                request: {
-                  method: method.toUpperCase(),
-                  url,
-                  body,
-                },
-                response: {
-                  status: response.status,
-                  statusText: response.statusText,
-                  headers: Object.fromEntries(response.headers.entries()),
-                  body: responseBody,
-                },
-              }, null, 2),
-            },
-          ],
-        };
-      }
-
-      default:
-        throw new Error(`Unknown tool: ${name}`);
-    }
+    return await handler(args);
   } catch (error) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify({
-            error: true,
-            message: error.message,
-          }, null, 2),
-        },
-      ],
-      isError: true,
-    };
+    return errorResponse(error.message);
   }
 });
+
+// Graceful shutdown
+async function shutdown() {
+  console.error('Shutting down mock servers...');
+
+  const shutdownPromises = [];
+  for (const [serverId, serverData] of servers) {
+    if (serverData.httpServer) {
+      shutdownPromises.push(
+        new Promise((resolve) => {
+          serverData.httpServer.close(() => resolve());
+          setTimeout(resolve, 5000); // Force resolve after 5s
+        })
+      );
+    }
+  }
+
+  await Promise.all(shutdownPromises);
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
 
 // Start the server
 async function main() {
@@ -1019,4 +949,7 @@ async function main() {
   console.error('mock-json-api MCP server running on stdio');
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error('Failed to start MCP server:', err);
+  process.exit(1);
+});

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1156 @@
+{
+  "name": "mock-json-api-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mock-json-api-mcp-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "mock-json-api": "file:.."
+      },
+      "bin": {
+        "mock-json-api-mcp": "index.js"
+      }
+    },
+    "..": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dummy-json": "^3.0.5",
+        "express": "^4.21.0",
+        "path-to-regexp": "^6.3.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "jest": "^29.7.0",
+        "supertest": "^7.0.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.25.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
+      "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
+      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mock-json-api": {
+      "resolved": "..",
+      "link": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "mock-json-api-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server for mock-json-api - manage mock REST APIs via Model Context Protocol",
+  "type": "module",
+  "main": "index.js",
+  "bin": {
+    "mock-json-api-mcp": "./index.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "mcp",
+    "mock",
+    "api",
+    "testing",
+    "model-context-protocol"
+  ],
+  "author": "Jeff Flater",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "mock-json-api": "file:.."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "typescript": "^5.3.0"
   },
   "scripts": {
-    "test": "jest --testPathPattern=__tests__",
-    "test:watch": "jest --watch --testPathPattern=__tests__",
-    "test:types": "tsc types.test.ts --noEmit --esModuleInterop --skipLibCheck"
+    "test": "jest --testPathPattern=__tests__ --testPathIgnorePatterns=mcp-server",
+    "test:watch": "jest --watch --testPathPattern=__tests__ --testPathIgnorePatterns=mcp-server",
+    "test:types": "tsc types.test.ts --noEmit --esModuleInterop --skipLibCheck",
+    "test:mcp": "cd mcp-server && npm test"
   }
 }


### PR DESCRIPTION
## Summary

- Add Model Context Protocol (MCP) server enabling AI assistants to create, configure, and control mock REST API servers
- 15 tools for server lifecycle, route management, presets, and testing
- Full documentation for both humans and AI agents

## Changes

### MCP Server (`mcp-server/`)
- **index.js**: Complete MCP server implementation with 15 tools
- **package.json**: Dependencies including @modelcontextprotocol/sdk
- **README.md**: Usage documentation, examples, troubleshooting

### Documentation
- **AGENTS.md**: AI agent installation guide with step-by-step instructions
- **README.md**: Added AI agent callout and MCP server section

### Tests
- **21 tests** covering route matching, all scopes, presets, server lifecycle

## MCP Tools

| Category | Tools |
|----------|-------|
| Server | `create_mock_server`, `start_server`, `stop_server`, `destroy_server`, `list_servers`, `get_server_info`, `reset_server` |
| Routes | `add_route`, `update_route`, `delete_route`, `set_scenario` |
| Presets | `list_presets`, `activate_preset`, `add_preset` |
| Testing | `test_route` |

## Test plan

- [x] All 21 tests pass (`npm test` in mcp-server/)
- [x] MCP server starts correctly
- [ ] Manual test with Claude Desktop

🤖 Generated with [Claude Code](https://claude.ai/code)